### PR TITLE
2D optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option( BUILD_UNIT_TESTS "Build unit tests using GoogleTest" ON )
 option( BUILD_CLI_UTILITIES "Build a set of command line utilities" ON )
 option( USE_ZSTD "Incorporate ZSTD to achieve further 5% reduction" OFF )
 option( QZ_TERM  "Coding terminates by quantization level" ON )
-option( BUILD_SHARED_LIBS "Build shared SPERR library" ON )
+option( BUILD_SHARED_LIBS "Build shared SPERR library" OFF )
 
 find_package(OpenMP REQUIRED)
 if( OpenMP_CXX_FOUND AND OpenMP_CXX_FLAGS )

--- a/include/SPECK2D.h
+++ b/include/SPECK2D.h
@@ -47,12 +47,16 @@ class SPECK2D : public SPECK_Storage {
   auto decode() -> RTNType;
 
  private:
-  auto m_sorting_pass() -> RTNType;
+  auto m_sorting_pass_encode() -> RTNType;
+  auto m_sorting_pass_decode() -> RTNType;
   auto m_refinement_pass_encode() -> RTNType;
   auto m_refinement_pass_decode() -> RTNType;
-  auto m_process_S(size_t, size_t, size_t&, bool) -> RTNType;
-  auto m_process_P(size_t, size_t&, bool) -> RTNType;
-  auto m_code_S(size_t, size_t) -> RTNType;
+  auto m_process_S_encode(size_t, size_t, size_t&, bool) -> RTNType;
+  auto m_process_S_decode(size_t, size_t, size_t&, bool) -> RTNType;
+  auto m_process_P_encode(size_t, size_t&, bool) -> RTNType;
+  auto m_process_P_decode(size_t, size_t&, bool) -> RTNType;
+  auto m_code_S_encode(size_t, size_t) -> RTNType;
+  auto m_code_S_decode(size_t, size_t) -> RTNType;
   auto m_process_I(bool) -> RTNType;
   auto m_code_I() -> RTNType;
   void m_initialize_sets_lists();

--- a/include/SPECK2D.h
+++ b/include/SPECK2D.h
@@ -3,6 +3,8 @@
 
 #include "SPECK_Storage.h"
 
+#include <limits>
+
 namespace sperr {
 
 //
@@ -48,17 +50,17 @@ class SPECK2D : public SPECK_Storage {
   auto m_sorting_pass() -> RTNType;
   auto m_refinement_pass_encode() -> RTNType;
   auto m_refinement_pass_decode() -> RTNType;
-  auto m_process_S(size_t, size_t, bool) -> RTNType;
+  auto m_process_S(size_t, size_t, size_t&, bool) -> RTNType;
   auto m_code_S(size_t, size_t) -> RTNType;
   auto m_process_I(bool) -> RTNType;
   auto m_code_I() -> RTNType;
   void m_initialize_sets_lists();
-  [[nodiscard]] auto m_partition_S(const SPECKSet2D&) const -> std::array<SPECKSet2D, 4>;
   auto m_partition_I() -> std::array<SPECKSet2D, 3>;
   auto m_decide_set_S_significance(const SPECKSet2D& set) -> SigType;
   auto m_decide_set_I_significance(const SPECKSet2D& set) -> SigType;
-  [[nodiscard]] auto m_produce_root() const -> SPECKSet2D;
   void m_clean_LIS();
+  [[nodiscard]] auto m_produce_root() const -> SPECKSet2D;
+  [[nodiscard]] auto m_partition_S(const SPECKSet2D&) const -> std::array<SPECKSet2D, 4>;
   [[nodiscard]] auto m_ready_to_encode() const -> bool;
   [[nodiscard]] auto m_ready_to_decode() const -> bool;
 
@@ -72,10 +74,14 @@ class SPECK2D : public SPECK_Storage {
 
   std::vector<bool> m_sign_array;
 
-  std::vector<size_t> m_LSP_new;
-  std::vector<size_t> m_LSP_old;
-  std::vector<std::vector<SPECKSet2D>> m_LIS;
+  std::vector<size_t> m_LSP_new;  // List of significant pixels, just identified
+  std::vector<size_t> m_LSP_old;  // List of significant pixels, previously identified
+
+  std::vector<std::vector<SPECKSet2D>> m_LIS; // List of insignificant sets
+  std::vector<size_t> m_LIP;                  // List of insignificant pixels
+
   SPECKSet2D m_I;
+  const size_t m_u64_garbage_val = std::numeric_limits<size_t>::max();
 };
 
 };  // namespace sperr

--- a/include/SPECK2D.h
+++ b/include/SPECK2D.h
@@ -51,6 +51,7 @@ class SPECK2D : public SPECK_Storage {
   auto m_refinement_pass_encode() -> RTNType;
   auto m_refinement_pass_decode() -> RTNType;
   auto m_process_S(size_t, size_t, size_t&, bool) -> RTNType;
+  auto m_process_P(size_t, size_t&, bool) -> RTNType;
   auto m_code_S(size_t, size_t) -> RTNType;
   auto m_process_I(bool) -> RTNType;
   auto m_code_I() -> RTNType;

--- a/include/SPECK3D.h
+++ b/include/SPECK3D.h
@@ -69,7 +69,7 @@ class SPECK3D : public SPECK_Storage {
   auto m_sorting_pass_encode() -> RTNType;
   auto m_sorting_pass_decode() -> RTNType;
 
-  // For the following 5 methods, indices are used to locate which set to
+  // For the following 6 methods, indices are used to locate which set to
   // process from m_LIS, Note that when process_S or process_P is called from a
   // code_S routine, code_S will pass in a counter to record how many subsets
   // are discovered significant already. That counter, however, doesn't do

--- a/include/sperr_helper.h
+++ b/include/sperr_helper.h
@@ -159,17 +159,25 @@ auto kahan_summation(const T*, size_t) -> T;
 
 // Given a whole volume size and a desired chunk size, this helper function
 // returns a list of chunks specified by 6 integers:
-// chunk[0], [2], [4]: starting index of this chunk;
-// chunk[1], [3], [5]: length of this chunk.
+// chunk[0], [2], [4]: starting index of this chunk in X, Y, and Z;
+// chunk[1], [3], [5]: length of this chunk in X, Y, and Z.
+// Note 1: the values in `chunk_dim` is only suggestive, meaning that when the volume
+//         dimension is not exact multiplies of requested chunk dimension,
+//         approximate values are used.
+// Note 2: this function works on degraded 2D or 1D volumes too.
 auto chunk_volume(const dims_type& vol_dim, const dims_type& chunk_dim)
     -> std::vector<std::array<size_t, 6>>;
 
 // Gather a chunk from a bigger volume
+// If the requested chunk lives outside of the volume, whole or part,
+// this function returns an empty vector.
 template <typename T1, typename T2>
 auto gather_chunk(const T1* vol, dims_type vol_dim, const std::array<size_t, 6>& chunk)
     -> std::vector<T2>;
 
 // Put this chunk to a bigger volume
+// The `big_vol` should have enough space allocated, and the `small_vol` should contain
+// enough elements to scatter. Memory errors will occur if the conditions are not met.
 template <typename TBIG, typename TSML>
 void scatter_chunk(std::vector<TBIG>& big_vol,
                    dims_type vol_dim,

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -334,15 +334,13 @@ auto sperr::SPECK2D::m_process_S_encode(size_t idx1,
 {
   auto& set = m_LIS[idx1][idx2];
   assert(!set.is_pixel());
+  set.signif = SigType::Sig;
 
   if (need_decide_sig) {
     set.signif = m_decide_set_S_significance(set);
     m_bit_buffer.push_back(set.signif == SigType::Sig);
     if (m_bit_buffer.size() >= m_budget)
       return RTNType::BitBudgetMet;
-  }
-  else {
-    set.signif = SigType::Sig;
   }
 
   if (set.signif == SigType::Sig) {
@@ -364,15 +362,13 @@ auto sperr::SPECK2D::m_process_S_decode(size_t idx1,
 {
   auto& set = m_LIS[idx1][idx2];
   assert(!set.is_pixel());
+  set.signif = SigType::Sig;
 
   if (need_decide_sig) {
     if (m_bit_idx >= m_budget)
       return RTNType::BitBudgetMet;
     const auto tmps = std::array<SigType, 2>{SigType::Insig, SigType::Sig};
     set.signif = tmps[m_bit_buffer[m_bit_idx++]];
-  }
-  else {
-    set.signif = SigType::Sig;
   }
 
   if (set.signif == SigType::Sig) {

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -185,7 +185,6 @@ auto sperr::SPECK2D::m_sorting_pass_encode() -> RTNType
     // From the end to the front of m_LIS, smaller sets first.
     size_t idx1 = m_LIS.size() - 1 - tmp;
     for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++) {
-      const auto& s = m_LIS[idx1][idx2];
       size_t dummy = 0;
       auto rtn = m_process_S_encode(idx1, idx2, dummy, true);
       if (rtn == RTNType::BitBudgetMet)
@@ -218,7 +217,6 @@ auto sperr::SPECK2D::m_sorting_pass_decode() -> RTNType
     // From the end to the front of m_LIS, smaller sets first.
     size_t idx1 = m_LIS.size() - 1 - tmp;
     for (size_t idx2 = 0; idx2 < m_LIS[idx1].size(); idx2++) {
-      const auto& s = m_LIS[idx1][idx2];
       size_t dummy = 0;
       auto rtn = m_process_S_decode(idx1, idx2, dummy, true);
       if (rtn == RTNType::BitBudgetMet)

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -272,7 +272,8 @@ auto sperr::SPECK2D::m_refinement_pass_encode() -> RTNType
   return RTNType::Good;
 }
 
-auto sperr::SPECK2D::m_process_P_encode(size_t loc, size_t& counter, bool need_decide_sig) -> RTNType
+auto sperr::SPECK2D::m_process_P_encode(size_t loc, size_t& counter, bool need_decide_sig)
+    -> RTNType
 {
   const auto pixel_idx = m_LIP[loc];
   auto p_sig = SigType::Sig;
@@ -300,7 +301,8 @@ auto sperr::SPECK2D::m_process_P_encode(size_t loc, size_t& counter, bool need_d
   return RTNType::Good;
 }
 
-auto sperr::SPECK2D::m_process_P_decode(size_t loc, size_t& counter, bool need_decide_sig) -> RTNType
+auto sperr::SPECK2D::m_process_P_decode(size_t loc, size_t& counter, bool need_decide_sig)
+    -> RTNType
 {
   const auto pixel_idx = m_LIP[loc];
   auto p_sig = SigType::Sig;
@@ -325,11 +327,13 @@ auto sperr::SPECK2D::m_process_P_decode(size_t loc, size_t& counter, bool need_d
   return RTNType::Good;
 }
 
-auto sperr::SPECK2D::m_process_S_encode(size_t idx1, size_t idx2, size_t& counter, bool need_decide_sig)
-    -> RTNType
+auto sperr::SPECK2D::m_process_S_encode(size_t idx1,
+                                        size_t idx2,
+                                        size_t& counter,
+                                        bool need_decide_sig) -> RTNType
 {
   auto& set = m_LIS[idx1][idx2];
-  assert( !set.is_pixel() );
+  assert(!set.is_pixel());
 
   if (need_decide_sig) {
     set.signif = m_decide_set_S_significance(set);
@@ -353,11 +357,13 @@ auto sperr::SPECK2D::m_process_S_encode(size_t idx1, size_t idx2, size_t& counte
   return RTNType::Good;
 }
 
-auto sperr::SPECK2D::m_process_S_decode(size_t idx1, size_t idx2, size_t& counter, bool need_decide_sig)
-    -> RTNType
+auto sperr::SPECK2D::m_process_S_decode(size_t idx1,
+                                        size_t idx2,
+                                        size_t& counter,
+                                        bool need_decide_sig) -> RTNType
 {
   auto& set = m_LIS[idx1][idx2];
-  assert( !set.is_pixel() );
+  assert(!set.is_pixel());
 
   if (need_decide_sig) {
     if (m_bit_idx >= m_budget)

--- a/src/SPECK2D_Decompressor.cpp
+++ b/src/SPECK2D_Decompressor.cpp
@@ -113,7 +113,7 @@ auto SPECK2D_Decompressor::get_data() const -> std::vector<T>
   auto out_buf = std::vector<T>(m_val_buf.size());
   std::copy(m_val_buf.begin(), m_val_buf.end(), out_buf.begin());
 
-  return std::move(out_buf);
+  return out_buf;
 }
 template auto SPECK2D_Decompressor::get_data() const -> std::vector<double>;
 template auto SPECK2D_Decompressor::get_data() const -> std::vector<float>;

--- a/src/SPERR.cpp
+++ b/src/SPERR.cpp
@@ -240,7 +240,7 @@ auto sperr::SPERR::m_decide_significance(const SPECKSet1D& set) const -> std::pa
     sig.first = true;
 
     // Note that `m_LSO` is sorted at the beginning of encoding.
-    auto idx_to_find = std::distance(m_sig_map.cbegin(), itr1);
+    size_t idx_to_find = std::distance(m_sig_map.cbegin(), itr1);
     auto itr2 = std::lower_bound(m_LOS.cbegin(), m_LOS.cend(), idx_to_find,
                                  [](const auto& otl, auto idx) { return otl.location < idx; });
     assert(itr2 != m_LOS.cend());

--- a/src/sperr_helper.cpp
+++ b/src/sperr_helper.cpp
@@ -355,6 +355,8 @@ auto sperr::chunk_volume(const std::array<size_t, 3>& vol_dim,
   auto n_segs = std::array<size_t, 3>();
   for (size_t i = 0; i < 3; i++) {
     n_segs[i] = vol_dim[i] / chunk_dim[i];
+    // In case the last segment is shorter than `chunk_dim[i]`, test if it's
+    // longer than half of `chunk_dim[i]`. If it is, it can qualify another segment.
     if ((vol_dim[i] % chunk_dim[i]) > (chunk_dim[i] / 2))
       n_segs[i]++;
     // In case the volume has one dimension that's too small, let's make it

--- a/test_scripts/speck2d_unit_test.cpp
+++ b/test_scripts/speck2d_unit_test.cpp
@@ -17,9 +17,9 @@ class speck_tester {
     m_dim_y = y;
   }
 
-  float get_psnr() const { return m_psnr; }
+  [[nodiscard]] float get_psnr() const { return m_psnr; }
 
-  float get_lmax() const { return m_lmax; }
+  [[nodiscard]] float get_lmax() const { return m_lmax; }
 
   // Execute the compression/decompression pipeline. Return 0 on success
   int execute(double bpp)

--- a/test_scripts/speck2d_unit_test.cpp
+++ b/test_scripts/speck2d_unit_test.cpp
@@ -111,22 +111,22 @@ TEST(speck2d, odd_dim_image)
   tester.execute(4.0f);
   float psnr = tester.get_psnr();
   float lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 58.7091);
-  EXPECT_LT(psnr, 58.7092);
-  EXPECT_LT(lmax, 0.7588);
+  EXPECT_GT(psnr, 58.7394);
+  EXPECT_LT(psnr, 58.7395);
+  EXPECT_LT(lmax, 0.77242);
 
   tester.execute(2.0f);
   psnr = tester.get_psnr();
   lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 46.7725);
-  EXPECT_LT(psnr, 46.7726);
-  EXPECT_LT(lmax, 2.9545);
+  EXPECT_GT(psnr, 46.8075);
+  EXPECT_LT(psnr, 46.8076);
+  EXPECT_LT(lmax, 2.95943);
 
   tester.execute(1.0f);
   psnr = tester.get_psnr();
   lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 40.0297);
-  EXPECT_LT(psnr, 40.0298);
+  EXPECT_GT(psnr, 40.0335);
+  EXPECT_LT(psnr, 40.0336);
   EXPECT_LT(lmax, 6.25197);
 
   tester.execute(0.5f);

--- a/test_scripts/speck3d_unit_test.cpp
+++ b/test_scripts/speck3d_unit_test.cpp
@@ -21,9 +21,9 @@ class speck_tester {
     m_dims = dims;
   }
 
-  float get_psnr() const { return m_psnr; }
+  [[nodiscard]] float get_psnr() const { return m_psnr; }
 
-  float get_lmax() const { return m_lmax; }
+  [[nodiscard]] float get_lmax() const { return m_lmax; }
 
   //
   // Execute the compression/decompression pipeline. Return 0 on success
@@ -107,9 +107,9 @@ class speck_tester_omp {
 
   void prefer_chunk_dims(sperr::dims_type dims) { m_chunk_dims = dims; }
 
-  float get_psnr() const { return m_psnr; }
+  [[nodiscard]] float get_psnr() const { return m_psnr; }
 
-  float get_lmax() const { return m_lmax; }
+  [[nodiscard]] float get_lmax() const { return m_lmax; }
 
   //
   // Execute the compression/decompression pipeline. Return 0 on success

--- a/test_scripts/sperr_helper_unit_test.cpp
+++ b/test_scripts/sperr_helper_unit_test.cpp
@@ -137,4 +137,54 @@ TEST(sperr_helper, bit_packing_1032_bools)
   }
 }
 
+TEST(sperr_helper, domain_decomposition)
+{
+  using sperr::dims_type;
+  using cdef = std::array<size_t, 6>;  // chunk definition
+
+  auto vol = dims_type{4, 4, 4};
+  auto subd = dims_type{1, 2, 3};
+
+  auto chunks = sperr::chunk_volume(vol, subd);
+  EXPECT_EQ(chunks.size(), 8);
+  auto chunk = cdef{0, 1, 0, 2, 0, 4};
+  EXPECT_EQ(chunks[0], chunk);
+  chunk = cdef{1, 1, 0, 2, 0, 4};
+  EXPECT_EQ(chunks[1], chunk);
+  chunk = cdef{2, 1, 0, 2, 0, 4};
+  EXPECT_EQ(chunks[2], chunk);
+  chunk = cdef{3, 1, 0, 2, 0, 4};
+  EXPECT_EQ(chunks[3], chunk);
+
+  chunk = cdef{0, 1, 2, 2, 0, 4};
+  EXPECT_EQ(chunks[4], chunk);
+  chunk = cdef{1, 1, 2, 2, 0, 4};
+  EXPECT_EQ(chunks[5], chunk);
+  chunk = cdef{2, 1, 2, 2, 0, 4};
+  EXPECT_EQ(chunks[6], chunk);
+  chunk = cdef{3, 1, 2, 2, 0, 4};
+  EXPECT_EQ(chunks[7], chunk);
+
+  vol = dims_type{4, 4, 1};  // will essentially require a decomposition on a 2D plane.
+  chunks = sperr::chunk_volume(vol, subd);
+  EXPECT_EQ(chunks.size(), 8);
+  chunk = cdef{0, 1, 0, 2, 0, 1};
+  EXPECT_EQ(chunks[0], chunk);
+  chunk = cdef{1, 1, 0, 2, 0, 1};
+  EXPECT_EQ(chunks[1], chunk);
+  chunk = cdef{2, 1, 0, 2, 0, 1};
+  EXPECT_EQ(chunks[2], chunk);
+  chunk = cdef{3, 1, 0, 2, 0, 1};
+  EXPECT_EQ(chunks[3], chunk);
+
+  chunk = cdef{0, 1, 2, 2, 0, 1};
+  EXPECT_EQ(chunks[4], chunk);
+  chunk = cdef{1, 1, 2, 2, 0, 1};
+  EXPECT_EQ(chunks[5], chunk);
+  chunk = cdef{2, 1, 2, 2, 0, 1};
+  EXPECT_EQ(chunks[6], chunk);
+  chunk = cdef{3, 1, 2, 2, 0, 1};
+  EXPECT_EQ(chunks[7], chunk);
+}
+
 }  // namespace


### PR DESCRIPTION
Brings multiple performance optimizations to 2D SPECK. The most significant two are:
1) Uses a list of indices, instead of sets, to represent pixels;
2) Separate encoding and decoding functions, so conditional jumps are less. 
They bring around 15% -- 20% performance improvements.

There are other minor code improvements as well. 