### PR TITLE
Q knob

### DIFF
--- a/include/SPECK2D_Compressor.h
+++ b/include/SPECK2D_Compressor.h
@@ -32,7 +32,7 @@ class SPECK2D_Compressor {
 
 #ifdef QZ_TERM
   void set_qz_level(int32_t);
-  auto set_tolerance(double) -> RTNType;
+  void set_tolerance(double);
   // Return 1) the number of outliers, and 2) the number of bytes to encode them.
   auto get_outlier_stats() const -> std::pair<size_t, size_t>;
 #else
@@ -52,11 +52,11 @@ class SPECK2D_Compressor {
 #ifdef QZ_TERM
   sperr::vec8_type m_sperr_stream;
   sperr::SPERR m_sperr;
-  sperr::vecd_type m_val_buf2;  // A copy of `m_val_buf` for outlier locating.
-  sperr::vecd_type m_diffv;     // Store differences to locate outliers.
+  sperr::vecd_type m_val_buf2;        // A copy of `m_val_buf` for outlier locating.
+  sperr::vecd_type m_diffv;           // Store differences to locate outliers.
+  std::vector<sperr::Outlier> m_LOS;  // List of OutlierS
   int32_t m_qz_lev = 0;
   double m_tol = 0.0;
-  size_t m_num_outlier = 0;
 #else
   double m_bpp = 0.0;
 #endif

--- a/include/SPECK2D_Compressor.h
+++ b/include/SPECK2D_Compressor.h
@@ -53,7 +53,6 @@ class SPECK2D_Compressor {
   sperr::vec8_type m_sperr_stream;
   sperr::SPERR m_sperr;
   sperr::vecd_type m_val_buf2;        // A copy of `m_val_buf` for outlier locating.
-  sperr::vecd_type m_diffv;           // Store differences to locate outliers.
   std::vector<sperr::Outlier> m_LOS;  // List of OutlierS
   int32_t m_qz_lev = 0;
   double m_tol = 0.0;

--- a/include/SPECK3D_Compressor.h
+++ b/include/SPECK3D_Compressor.h
@@ -36,7 +36,7 @@ class SPECK3D_Compressor {
 
 #ifdef QZ_TERM
   void set_qz_level(int32_t);
-  auto set_tolerance(double) -> RTNType;
+  void set_tolerance(double);
   // Return 1) the number of outliers, and 2) the number of bytes to encode them.
   auto get_outlier_stats() const -> std::pair<size_t, size_t>;
 #else

--- a/include/SPECK3D_Compressor.h
+++ b/include/SPECK3D_Compressor.h
@@ -71,7 +71,6 @@ class SPECK3D_Compressor {
   double m_tol = 0.0;                 // tolerance used in error correction
   std::vector<sperr::Outlier> m_LOS;  // List of OutlierS
   sperr::vecd_type m_val_buf2;        // Copy of `m_val_buf` that goes through encoding.
-  sperr::vecd_type m_diffv;           // Store differences to locate outliers.
 #else
   double m_bpp = 0.0;
 #endif

--- a/include/SPECK3D_OMP_C.h
+++ b/include/SPECK3D_OMP_C.h
@@ -25,9 +25,9 @@ class SPECK3D_OMP_C {
 
 #ifdef QZ_TERM
   void set_qz_level(int32_t);
-  auto set_tolerance(double) -> RTNType;
+  void set_tolerance(double);
   // Return 1) the number of outliers, and 2) the num of bytes to encode them.
-  [[nodiscard]] auto get_outlier_stats() const -> std::pair<size_t, size_t>;
+  auto get_outlier_stats() const -> std::pair<size_t, size_t>;
 #else
   auto set_bpp(double) -> RTNType;
 #endif
@@ -35,7 +35,7 @@ class SPECK3D_OMP_C {
   auto compress() -> RTNType;
 
   // Provide a copy of the encoded bitstream to the caller.
-  [[nodiscard]] auto get_encoded_bitstream() const -> std::vector<uint8_t>;
+  auto get_encoded_bitstream() const -> std::vector<uint8_t>;
 
  private:
   sperr::dims_type m_dims = {0, 0, 0};        // Dimension of the entire volume

--- a/src/SPECK2D_Compressor.cpp
+++ b/src/SPECK2D_Compressor.cpp
@@ -165,17 +165,16 @@ auto SPECK2D_Compressor::compress() -> RTNType
     // Note: the cumbersome calculations below prevents the situation where deviations
     // are below the threshold in double precision, but above in single precision!
     auto new_tol = m_tol;
-    m_diffv.resize(total_vals);
-    std::transform(m_val_buf.cbegin(), m_val_buf.cend(), m_val_buf2.cbegin(), m_diffv.begin(),
-                   [](auto v, auto v2) { return v2 - v; });
     for (size_t i = 0; i < total_vals; i++) {
-      auto f = std::abs(float(m_val_buf2[i]) - float(m_val_buf[i]));
-      if (double(f) > m_tol && std::abs(m_diffv[i]) <= m_tol)
-        new_tol = std::min(new_tol, std::abs(m_diffv[i]));
+      const auto d = std::abs(m_val_buf2[i] - m_val_buf[i]);
+      const float f = std::abs(float(m_val_buf2[i]) - float(m_val_buf[i]));
+      if (double(f) > m_tol && d <= m_tol)
+        new_tol = std::min(new_tol, d);
     }
     for (size_t i = 0; i < total_vals; i++) {
-      if (std::abs(m_diffv[i]) > new_tol)
-        m_LOS.emplace_back(i, m_diffv[i]);
+      const auto diff = m_val_buf2[i] - m_val_buf[i];
+      if (std::abs(diff) > new_tol)
+        m_LOS.emplace_back(i, diff);
     }
 
     // Step 6: actually encode located outliers

--- a/src/SPECK3D_Compressor.cpp
+++ b/src/SPECK3D_Compressor.cpp
@@ -308,7 +308,7 @@ void SPECK3D_Compressor::set_qz_level(int32_t q)
 {
   m_qz_lev = q;
 }
-void SPECK3D_Compressor::set_tolerance(double tol);
+void SPECK3D_Compressor::set_tolerance(double tol)
 {
   m_tol = tol;
 }

--- a/src/SPECK3D_Compressor.cpp
+++ b/src/SPECK3D_Compressor.cpp
@@ -64,20 +64,28 @@ auto SPECK3D_Compressor::compress() -> RTNType
     return tmp;
   }
 
-  // Note that we keep the original buffer untouched for outlier calculations later.
-  // The buffer `m_val_buf2` will be recycled and reused.
-  m_val_buf2.resize(m_val_buf.size());
-  std::copy(m_val_buf.begin(), m_val_buf.end(), m_val_buf2.begin());
+  // Note: in the case where a positive error tolerance is given, this
+  // method also performs error detection and correction.
+  // In the case where a zero or negative error tolerance is given, this
+  // method simply performs SPECK encoding and terminates at the specifie
+  // quantization level.
 
-  // Step 1: data (m_val_buf2) goes through the conditioner
+  if (m_tol > 0.0) {
+    m_val_buf2.resize(m_val_buf.size());
+    std::copy(m_val_buf.begin(), m_val_buf.end(), m_val_buf2.begin());
+  }
+  else
+    m_val_buf2.clear();
+
+  // Step 1: data goes through the conditioner
   m_conditioner.toggle_all_settings(m_conditioning_settings);
-  auto [rtn, condi_meta] = m_conditioner.condition(m_val_buf2);
+  auto [rtn, condi_meta] = m_conditioner.condition(m_val_buf);
   if (rtn != RTNType::Good)
     return rtn;
   m_condi_stream = condi_meta;
 
   // Step 2: wavelet transform
-  rtn = m_cdf.take_data(std::move(m_val_buf2), m_dims);
+  rtn = m_cdf.take_data(std::move(m_val_buf), m_dims);
   if (rtn != RTNType::Good)
     return rtn;
   // Figure out which dwt3d strategy to use.
@@ -101,50 +109,58 @@ auto SPECK3D_Compressor::compress() -> RTNType
   if (m_speck_stream.empty())
     return RTNType::Error;
 
-  // Step 4: perform a decompression pass (reusing the same object states and memory blocks).
-  rtn = m_encoder.decode();
-  if (rtn != RTNType::Good)
-    return rtn;
-  m_cdf.take_data(m_encoder.release_data(), m_dims);
-  if (xforms_xy == xforms_z)
-    m_cdf.idwt3d_dyadic();
-  else
-    m_cdf.idwt3d_wavelet_packet();
-  m_val_buf2 = m_cdf.release_data();
-  m_conditioner.inverse_condition(m_val_buf2, m_condi_stream);
-
-  // Step 5: we find all the outliers!
+  // Optional steps: outlier detection and correction
   //
-  // Observation: for some data points, the reconstruction error in double falls
-  // below `m_tol`, while in float would fall above `m_tol`. (Github issue #78).
-  // Solution: find those data points, and use their slightly reduced error as
-  // the new tolerance.
-  //
-  auto new_tol = m_tol;
-  m_diffv.resize(total_vals);
-  for (size_t i = 0; i < total_vals; i++)
-    m_diffv[i] = m_val_buf[i] - m_val_buf2[i];
-  for (size_t i = 0; i < total_vals; i++) {
-    auto f = std::abs(float(m_val_buf[i]) - float(m_val_buf2[i]));
-    if (double(f) > m_tol && std::abs(m_diffv[i]) <= m_tol)
-      new_tol = std::min(new_tol, std::abs(m_diffv[i]));
-  }
-  for (size_t i = 0; i < total_vals; i++) {
-    if (std::abs(m_diffv[i]) > new_tol)
-      m_LOS.emplace_back(i, m_diffv[i]);
-  }
-
-  // Step 6: encode any outlier that's found.
-  if (!m_LOS.empty()) {
-    m_sperr.set_tolerance(new_tol);
-    m_sperr.set_length(total_vals);
-    m_sperr.copy_outlier_list(m_LOS);
-    rtn = m_sperr.encode();
+  if (m_tol > 0.0) {
+    // Step 4: perform a decompression pass
+    rtn = m_encoder.decode();
     if (rtn != RTNType::Good)
       return rtn;
-    m_sperr_stream = m_sperr.get_encoded_bitstream();
-    if (m_sperr_stream.empty())
-      return RTNType::Error;
+    m_cdf.take_data(m_encoder.release_data(), m_dims);
+    if (xforms_xy == xforms_z)
+      m_cdf.idwt3d_dyadic();
+    else
+      m_cdf.idwt3d_wavelet_packet();
+    m_val_buf = m_cdf.release_data();
+    m_conditioner.inverse_condition(m_val_buf, m_condi_stream);
+
+    // Step 5: we find all the outliers!
+    //
+    // Observation: for some data points, the reconstruction error in double falls
+    // below `m_tol`, while in float would fall above `m_tol`. (Github issue #78).
+    // Solution: find those data points, and use their slightly reduced error as
+    // the new tolerance.
+    //
+    auto new_tol = m_tol;
+    m_diffv.resize(total_vals);
+    for (size_t i = 0; i < total_vals; i++)
+      m_diffv[i] = m_val_buf2[i] - m_val_buf[i];
+    for (size_t i = 0; i < total_vals; i++) {
+      auto f = std::abs(float(m_val_buf2[i]) - float(m_val_buf[i]));
+      if (double(f) > m_tol && std::abs(m_diffv[i]) <= m_tol)
+        new_tol = std::min(new_tol, std::abs(m_diffv[i]));
+    }
+    for (size_t i = 0; i < total_vals; i++) {
+      if (std::abs(m_diffv[i]) > new_tol)
+        m_LOS.emplace_back(i, m_diffv[i]);
+    }
+
+    // Step 6: encode any outlier that's found.
+    if (!m_LOS.empty()) {
+      m_sperr.set_tolerance(new_tol);
+      m_sperr.set_length(total_vals);
+      m_sperr.copy_outlier_list(m_LOS);
+      rtn = m_sperr.encode();
+      if (rtn != RTNType::Good)
+        return rtn;
+      m_sperr_stream = m_sperr.get_encoded_bitstream();
+      if (m_sperr_stream.empty())
+        return RTNType::Error;
+    }
+  } // Finish outlier detection and correction
+  else {
+    // Return the memory block to `m_val_buf`.
+    m_val_buf = m_encoder.release_data();
   }
 
   rtn = m_assemble_encoded_bitstream();

--- a/src/SPECK3D_Compressor.cpp
+++ b/src/SPECK3D_Compressor.cpp
@@ -137,8 +137,8 @@ auto SPECK3D_Compressor::compress() -> RTNType
     //
     auto new_tol = m_tol;
     m_diffv.resize(total_vals);
-    for (size_t i = 0; i < total_vals; i++)
-      m_diffv[i] = m_val_buf2[i] - m_val_buf[i];
+    std::transform(m_val_buf.cbegin(), m_val_buf.cend(), m_val_buf2.cbegin(), m_diffv.begin(),
+                   [](auto v, auto v2) { return v2 - v; });
     for (size_t i = 0; i < total_vals; i++) {
       auto f = std::abs(float(m_val_buf2[i]) - float(m_val_buf[i]));
       if (double(f) > m_tol && std::abs(m_diffv[i]) <= m_tol)
@@ -161,7 +161,7 @@ auto SPECK3D_Compressor::compress() -> RTNType
       if (m_sperr_stream.empty())
         return RTNType::Error;
     }
-  } // Finish outlier detection and correction
+  }  // Finish outlier detection and correction
 
   rtn = m_assemble_encoded_bitstream();
 

--- a/src/SPECK3D_Compressor.cpp
+++ b/src/SPECK3D_Compressor.cpp
@@ -136,17 +136,16 @@ auto SPECK3D_Compressor::compress() -> RTNType
     // the new tolerance.
     //
     auto new_tol = m_tol;
-    m_diffv.resize(total_vals);
-    std::transform(m_val_buf.cbegin(), m_val_buf.cend(), m_val_buf2.cbegin(), m_diffv.begin(),
-                   [](auto v, auto v2) { return v2 - v; });
     for (size_t i = 0; i < total_vals; i++) {
-      auto f = std::abs(float(m_val_buf2[i]) - float(m_val_buf[i]));
-      if (double(f) > m_tol && std::abs(m_diffv[i]) <= m_tol)
-        new_tol = std::min(new_tol, std::abs(m_diffv[i]));
+      const auto d = std::abs(m_val_buf2[i] - m_val_buf[i]);
+      const float f = std::abs(float(m_val_buf2[i]) - float(m_val_buf[i]));
+      if (double(f) > m_tol && d <= m_tol)
+        new_tol = std::min(new_tol, d);
     }
     for (size_t i = 0; i < total_vals; i++) {
-      if (std::abs(m_diffv[i]) > new_tol)
-        m_LOS.emplace_back(i, m_diffv[i]);
+      const auto diff = m_val_buf2[i] - m_val_buf[i];
+      if (std::abs(diff) > new_tol)
+        m_LOS.emplace_back(i, diff);
     }
 
     // Step 6: encode any outlier that's found.

--- a/src/SPECK3D_Compressor.cpp
+++ b/src/SPECK3D_Compressor.cpp
@@ -308,15 +308,9 @@ void SPECK3D_Compressor::set_qz_level(int32_t q)
 {
   m_qz_lev = q;
 }
-auto SPECK3D_Compressor::set_tolerance(double tol) -> RTNType
+void SPECK3D_Compressor::set_tolerance(double tol);
 {
-  if (tol <= 0.0)
-    return RTNType::InvalidParam;
-  else {
-    m_tol = tol;
-    m_sperr.set_tolerance(tol);
-    return RTNType::Good;
-  }
+  m_tol = tol;
 }
 auto SPECK3D_Compressor::get_outlier_stats() const -> std::pair<size_t, size_t>
 {

--- a/src/SPECK3D_Compressor.cpp
+++ b/src/SPECK3D_Compressor.cpp
@@ -109,9 +109,13 @@ auto SPECK3D_Compressor::compress() -> RTNType
   if (m_speck_stream.empty())
     return RTNType::Error;
 
-  // Optional steps: outlier detection and correction
-  //
-  if (m_tol > 0.0) {
+  if (m_tol <= 0.0) {
+    // Not doing outlier correction, directly return the memory block to `m_val_buf`.
+    m_val_buf = m_encoder.release_data();
+  }
+  else {
+    // Optional steps: outlier detection and correction
+    //
     // Step 4: perform a decompression pass
     rtn = m_encoder.decode();
     if (rtn != RTNType::Good)
@@ -158,10 +162,6 @@ auto SPECK3D_Compressor::compress() -> RTNType
         return RTNType::Error;
     }
   } // Finish outlier detection and correction
-  else {
-    // Return the memory block to `m_val_buf`.
-    m_val_buf = m_encoder.release_data();
-  }
 
   rtn = m_assemble_encoded_bitstream();
 

--- a/src/SPECK3D_OMP_C.cpp
+++ b/src/SPECK3D_OMP_C.cpp
@@ -22,14 +22,9 @@ void SPECK3D_OMP_C::set_qz_level(int32_t q)
 {
   m_qz_lev = q;
 }
-auto SPECK3D_OMP_C::set_tolerance(double t) -> RTNType
+void SPECK3D_OMP_C::set_tolerance(double t)
 {
-  if (t <= 0.0)
-    return RTNType::InvalidParam;
-  else {
-    m_tol = t;
-    return RTNType::Good;
-  }
+  m_tol = t;
 }
 auto SPECK3D_OMP_C::get_outlier_stats() const -> std::pair<size_t, size_t>
 {

--- a/src/sperr_helper.cpp
+++ b/src/sperr_helper.cpp
@@ -318,11 +318,10 @@ auto sperr::calc_stats(const T* arr1, const T* arr2, size_t arr_len, size_t omp_
   // http://homepages.inf.ed.ac.uk/rbf/CVonline/LOCAL_COPIES/VELDHUIZEN/node18.html
   // Also refer to https://www.mathworks.com/help/vision/ref/psnr.html
   //
-  const auto msr = std::accumulate(sum_vec.begin(), sum_vec.end(), T{0.0}) / T(arr_len);
-  rmse = std::sqrt(msr);
-  auto range_sq = *minmax.first - *minmax.second;
-  range_sq *= range_sq;
-  psnr = std::log10(range_sq / msr) * T{10.0};
+  const auto mse = std::accumulate(sum_vec.begin(), sum_vec.end(), T{0.0}) / T(arr_len);
+  rmse = std::sqrt(mse);
+  const auto range_sq = (arr1max - arr1min) * (arr1max - arr1min);
+  psnr = std::log10(range_sq / mse) * T{10.0};
 
   return {rmse, linfty, psnr, arr1min, arr1max};
 }

--- a/test_scripts/speck2d_unit_test.cpp
+++ b/test_scripts/speck2d_unit_test.cpp
@@ -50,8 +50,7 @@ class speck_tester {
 
 #ifdef QZ_TERM
     compressor.set_qz_level(q);
-    if (compressor.set_tolerance(tol) != RTNType::Good)
-      return 1;
+    compressor.set_tolerance(tol);
 #else
     if (compressor.set_bpp(bpp) != RTNType::Good)
       return 1;

--- a/test_scripts/speck3d_unit_test.cpp
+++ b/test_scripts/speck3d_unit_test.cpp
@@ -54,8 +54,7 @@ class speck_tester {
 
 #ifdef QZ_TERM
     compressor.set_qz_level(qz_level);
-    if (compressor.set_tolerance(tol) != RTNType::Good)
-      return 1;
+    compressor.set_tolerance(tol);
 #else
     if (compressor.set_bpp(bpp) != RTNType::Good)
       return 1;

--- a/utilities/compressor_2d.cpp
+++ b/utilities/compressor_2d.cpp
@@ -44,10 +44,11 @@ int main(int argc, char* argv[])
       ->required();
 
   auto tolerance = double{0.0};
-  app.add_option("-t", tolerance, "Maximum point-wise error tolerance. E.g., `-t 1e-2`")
-      ->check(CLI::PositiveNumber)
-      ->group("Compression Parameters")
-      ->required();
+  app.add_option("-t", tolerance,
+                 "Maximum point-wise error tolerance. E.g., `-t 1e-2`\n"
+                 "If not specified or a negative number is given, \n"
+                 "then the program will not perform any outlier correction.")
+      ->group("Compression Parameters");
 #else
   auto bpp = double{0.0};
   app.add_option("--bpp", bpp, "Target bit-per-pixel. E.g., `--bpp 4.5`")
@@ -156,8 +157,8 @@ int main(int argc, char* argv[])
     }
     else {
       printf(
-          "There were %ld outliers, percentage = %.2f%%.\n"
-          "Correcting them takes bpp = %.2f, using total storage = %.2f%%\n",
+          "There were %ld outliers, percentage of total data points = %.2f%%.\n"
+          "Correcting them takes bpp = %.2f, percentage of total storage = %.2f%%\n",
           out_stats.first, double(out_stats.first * 100) / double(total_vals),
           double(out_stats.second * 8) / double(out_stats.first),
           double(out_stats.second * 100) / double(stream.size()));

--- a/utilities/compressor_3d.cpp
+++ b/utilities/compressor_3d.cpp
@@ -49,10 +49,11 @@ int main(int argc, char* argv[])
       ->required();
 
   auto tolerance = double{0.0};
-  app.add_option("-t", tolerance, "Maximum point-wise error tolerance. E.g., `-t 1e-2`")
-      ->check(CLI::PositiveNumber)
-      ->group("Compression Parameters")
-      ->required();
+  app.add_option("-t", tolerance,
+                 "Maximum point-wise error tolerance. E.g., `-t 1e-2`\n"
+                 "If not specified or a negative number is given, \n"
+                 "then the program will not perform any outlier correction.")
+      ->group("Compression Parameters");
 #else
   auto bpp = double{0.0};
   app.add_option("--bpp", bpp, "Target bit-per-pixel. E.g., `--bpp 2.3`")

--- a/utilities/probe_3d_qz.cpp
+++ b/utilities/probe_3d_qz.cpp
@@ -131,11 +131,11 @@ int main(int argc, char* argv[])
 
   auto tolerance = double{0.0};
   app.add_option("-t", tolerance,
-                 "Maximum point-wise error tolerance. E.g., `-t 0.001`.\n"
-                 "Note: if flag --div-rms is enabled, then this tolerance\n"
-                 "applies to conditioned data.")
-      ->required()
-      ->check(CLI::PositiveNumber)
+                 "Maximum point-wise error tolerance. E.g., `-t 1e-3`.\n"
+                 "Note1 : if flag --div-rms is enabled, then this tolerance\n"
+                 "applies to conditioned data.\n"
+                 "Note 2: If not specified or a negative number is given, \n"
+                 "then the program will not perform any outlier correction.")
       ->group("Compression Parameters");
 
   auto qz_level = int32_t{0};


### PR DESCRIPTION
This PR changes the behavior of error-bounded compression so that when a zero or negative tolerance is passed in, the algorithm bypasses outlier correction completely. The result is that `q` can be used as a sole quality control knob as suggested in #131 .

There are minor improvements here and there as well. 