### PR TITLE
Speedy size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-project(SPERR VERSION 0.1 DESCRIPTION "Lossy Scientific Compression with SPERR")
+project(SPERR VERSION 0.2 DESCRIPTION "Lossy Scientific Compression with SPERR")
 
 #
 # specify the C++ standard

--- a/include/SPECK2D.h
+++ b/include/SPECK2D.h
@@ -98,8 +98,8 @@ class SPECK2D : public SPECK_Storage {
 #else
   double m_threshold = 0.0;       // Threshold that's used for an iteration.
   std::vector<size_t> m_LSP_new;  // List of significant pixels, just identified
-  //std::vector<size_t> m_LSP_old;  // List of significant pixels, previously identified
-  std::vector<bool> m_LSP_mask;
+  std::vector<bool> m_LSP_mask;   // Old significant pixels
+  size_t m_LSP_count = 0;         // TODO: the number of old significant pixels.
   size_t m_budget = 0;            // What's the budget for num of bits in fixed-rate mode?
 #endif
 

--- a/include/SPECK2D.h
+++ b/include/SPECK2D.h
@@ -99,7 +99,7 @@ class SPECK2D : public SPECK_Storage {
   double m_threshold = 0.0;       // Threshold that's used for an iteration.
   std::vector<size_t> m_LSP_new;  // List of significant pixels, just identified
   std::vector<bool> m_LSP_mask;   // Old significant pixels
-  size_t m_LSP_count = 0;         // TODO: the number of old significant pixels.
+  size_t m_LSP_count = 0;         // The number of old significant pixels.
   size_t m_budget = 0;            // What's the budget for num of bits in fixed-rate mode?
 #endif
 

--- a/include/SPECK2D.h
+++ b/include/SPECK2D.h
@@ -98,7 +98,8 @@ class SPECK2D : public SPECK_Storage {
 #else
   double m_threshold = 0.0;       // Threshold that's used for an iteration.
   std::vector<size_t> m_LSP_new;  // List of significant pixels, just identified
-  std::vector<size_t> m_LSP_old;  // List of significant pixels, previously identified
+  //std::vector<size_t> m_LSP_old;  // List of significant pixels, previously identified
+  std::vector<bool> m_LSP_mask;
   size_t m_budget = 0;            // What's the budget for num of bits in fixed-rate mode?
 #endif
 

--- a/include/SPECK2D.h
+++ b/include/SPECK2D.h
@@ -97,12 +97,10 @@ class SPECK2D : public SPECK_Storage {
   size_t m_threshold_idx = 0;
 #else
   double m_threshold = 0.0;       // Threshold that's used for an iteration.
-  std::vector<size_t> m_LSP_new;  // List of significant pixels, just identified
-  std::vector<bool> m_LSP_mask;   // Old significant pixels
-  size_t m_LSP_count = 0;         // The number of old significant pixels.
+  std::vector<size_t> m_LSP_new;  // List of newly found significant pixels
+  std::vector<bool> m_LSP_mask;   // Significant pixels previously found
   size_t m_budget = 0;            // What's the budget for num of bits in fixed-rate mode?
 #endif
-
 };
 
 };  // namespace sperr

--- a/include/SPECK3D.h
+++ b/include/SPECK3D.h
@@ -40,6 +40,7 @@ class SPECKSet3D {
 //
 class SPECK3D : public SPECK_Storage {
  public:
+
 #ifdef QZ_TERM
   //
   // Notes for QZ_TERM mode:
@@ -111,7 +112,7 @@ class SPECK3D : public SPECK_Storage {
 
 #ifndef QZ_TERM
   std::vector<size_t> m_LSP_new;
-  std::vector<size_t> m_LSP_old;
+  std::vector<bool> m_LSP_mask;
   size_t m_budget = 0;
 #endif
 

--- a/include/SPECK3D.h
+++ b/include/SPECK3D.h
@@ -40,7 +40,6 @@ class SPECKSet3D {
 //
 class SPECK3D : public SPECK_Storage {
  public:
-
 #ifdef QZ_TERM
   //
   // Notes for QZ_TERM mode:

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -138,8 +138,9 @@ auto sperr::SPECK2D::decode() -> RTNType
 #endif
 
   // Initialize coefficients to be zero and insignificant, and signs to be all positive.
-  m_coeff_buf.assign(m_coeff_buf.size(), 0.0);
-  m_sign_array.assign(m_coeff_buf.size(), true);
+  const auto coeff_len = m_dims[0] * m_dims[1];
+  m_coeff_buf.assign(coeff_len, 0.0);
+  m_sign_array.assign(coeff_len, true);
 
 #ifndef QZ_TERM
   // Mark every coefficient as insignificant

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -359,7 +359,7 @@ auto sperr::SPECK2D::m_refinement_pass_encode() -> RTNType
     if (m_LSP_mask[i]) { // A significant pixel at this location
       const size_t o1 = m_coeff_buf[i] >= m_threshold;
       m_coeff_buf[i] += tmpd[o1];
-      m_bit_buffer.push_back(tmpb[i]);
+      m_bit_buffer.push_back(tmpb[o1]);
       
       if (m_bit_buffer.size() >= m_budget)
         return RTNType::BitBudgetMet;
@@ -396,7 +396,7 @@ auto sperr::SPECK2D::m_refinement_pass_decode() -> RTNType
 
   for (size_t i = 0; i < m_LSP_mask.size(); i++) {
     if (m_LSP_mask[i]) {
-      m_coeff_buf[i] += tmp[m_bit_idx++];
+      m_coeff_buf[i] += tmp[m_bit_buffer[m_bit_idx++]];
 
       if (m_bit_idx >= m_budget)
         return RTNType::BitBudgetMet;

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -137,7 +137,7 @@ auto sperr::SPECK2D::decode() -> RTNType
     m_budget = m_bit_buffer.size();
 #endif
 
-  // Initialize coefficients to be zero and insignificant, and signs to be all positive.
+  // Initialize coefficients to be zero, and signs to be all positive.
   const auto coeff_len = m_dims[0] * m_dims[1];
   m_coeff_buf.assign(coeff_len, 0.0);
   m_sign_array.assign(coeff_len, true);

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -63,7 +63,10 @@ auto sperr::SPECK2D::encode() -> RTNType
 
   m_encoded_stream.clear();
   m_bit_buffer.clear();
+
+#ifndef QZ_TERM
   m_LSP_mask.assign(m_coeff_buf.size(), false);
+#endif
 
   // Keep signs of all coefficients
   m_sign_array.resize(m_coeff_buf.size());
@@ -135,8 +138,11 @@ auto sperr::SPECK2D::decode() -> RTNType
 
   // Initialize coefficients to be zero and insignificant, and signs to be all positive.
   m_coeff_buf.assign(m_coeff_buf.size(), 0.0);
-  m_LSP_mask.assign(m_coeff_buf.size(), false);
   m_sign_array.assign(m_coeff_buf.size(), true);
+
+#ifndef QZ_TERM
+  m_LSP_mask.assign(m_coeff_buf.size(), false);
+#endif
 
   m_initialize_sets_lists();
   m_bit_idx = 0;

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -240,7 +240,7 @@ auto sperr::SPECK2D::m_sorting_pass_encode() -> RTNType
 {
   // First, process all insignificant pixels
   //
-  size_t dummy = 0;
+  auto dummy = size_t{0};
   for (size_t idx = 0; idx < m_LIP.size(); idx++) {
     auto rtn = m_process_P_encode(idx, dummy, true);
 #ifndef QZ_TERM

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -218,8 +218,9 @@ void sperr::SPECK2D::m_initialize_sets_lists()
   // clear lists and reserve space.
   m_LSP_new.clear();
   m_LSP_new.reserve(m_coeff_buf.size() / 8);
-  m_LSP_old.clear();
-  m_LSP_old.reserve(m_coeff_buf.size() / 2);
+  //m_LSP_old.clear();
+  //m_LSP_old.reserve(m_coeff_buf.size() / 2);
+  m_LSP_mask.reserve(m_coeff_buf.size());
   m_bit_buffer.reserve(m_budget);
 #endif
 }

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -178,13 +178,6 @@ auto sperr::SPECK2D::decode() -> RTNType
     m_threshold *= 0.5;
     m_clean_LIS();
   }
-
-  // If decoding finished before all newly-identified significant pixels are initialized in
-  // `m_refinement_pass_decode()`, we have them initialized here.
-  // TODO: Do I still need this?
-  for (auto idx : m_LSP_new)
-    m_coeff_buf[idx] = m_threshold * 1.5;
-  m_LSP_new.clear();
 #endif
 
   // Restore coefficient signs

--- a/src/SPECK3D.cpp
+++ b/src/SPECK3D.cpp
@@ -353,10 +353,11 @@ auto sperr::SPECK3D::m_process_P_encode(size_t loc, SigType sig, size_t& counter
 
   // Decide the significance of this pixel
   assert(sig != SigType::NewlySig);
-  bool is_sig = (sig == SigType::Sig);
-  if (sig == SigType::Dunno) {
+  bool is_sig = false;
+  if (sig == SigType::Dunno)
     is_sig = (m_coeff_buf[pixel_idx] >= m_threshold_arr[m_threshold_idx]);
-  }
+  else
+    is_sig = (sig == SigType::Sig);
 
   if (output) {
     // Output significance bit

--- a/src/SPECK3D.cpp
+++ b/src/SPECK3D.cpp
@@ -166,7 +166,6 @@ auto sperr::SPECK3D::decode() -> RTNType
                 [v = m_threshold_arr[0]]() mutable { return std::exchange(v, v * 0.5); });
 
   for (m_threshold_idx = 0; m_threshold_idx < m_threshold_arr.size(); m_threshold_idx++) {
-
 #ifdef QZ_TERM
     m_sorting_pass_decode();
     if (m_bit_idx > m_bit_buffer.size())
@@ -227,9 +226,12 @@ void sperr::SPECK3D::m_initialize_sets_lists()
   // Starting from a set representing the whole volume, identify the smaller
   // sets and put them in LIS accordingly.
   SPECKSet3D big;
-  big.length_x = uint32_t(m_dims[0]);  // Truncate 64-bit int to 32-bit, but should be OK.
-  big.length_y = uint32_t(m_dims[1]);  // Truncate 64-bit int to 32-bit, but should be OK.
-  big.length_z = uint32_t(m_dims[2]);  // Truncate 64-bit int to 32-bit, but should be OK.
+  big.length_x =
+      static_cast<uint32_t>(m_dims[0]);  // Truncate 64-bit int to 32-bit, but should be OK.
+  big.length_y =
+      static_cast<uint32_t>(m_dims[1]);  // Truncate 64-bit int to 32-bit, but should be OK.
+  big.length_z =
+      static_cast<uint32_t>(m_dims[2]);  // Truncate 64-bit int to 32-bit, but should be OK.
 
   const auto num_of_xforms_xy = sperr::num_of_xforms(std::min(m_dims[0], m_dims[1]));
   const auto num_of_xforms_z = sperr::num_of_xforms(m_dims[2]);
@@ -432,16 +434,6 @@ auto sperr::SPECK3D::m_refinement_pass_encode() -> RTNType
   const auto tmpb = b2_type{false, true};
   const auto tmpd = d2_type{0.0, -m_threshold_arr[m_threshold_idx]};
 
-  //const size_t n_to_process = std::min(m_LSP_old.size(), m_budget - m_bit_buffer.size());
-  //for (size_t i = 0; i < n_to_process; i++) {
-  //  const size_t loc = m_LSP_old[i];
-  //  const size_t o1 = m_coeff_buf[loc] >= m_threshold_arr[m_threshold_idx];
-  //  m_coeff_buf[loc] += tmpd[o1];
-  //  m_bit_buffer.push_back(tmpb[o1]);
-  //}
-  //if (m_bit_buffer.size() >= m_budget)
-  //  return RTNType::BitBudgetMet;
-
   for (size_t i = 0; i < m_LSP_mask.size(); i++) {
     if (m_LSP_mask[i]) {
       const size_t o1 = m_coeff_buf[i] >= m_threshold_arr[m_threshold_idx];
@@ -466,17 +458,8 @@ auto sperr::SPECK3D::m_refinement_pass_decode() -> RTNType
 {
   // First, process significant pixels previously found.
   //
-  //const size_t num_bits = std::min(m_budget - m_bit_idx, m_LSP_old.size());
-  //const double one_half_T = m_threshold_arr[m_threshold_idx] * 1.5;
-  const double half_T = m_threshold_arr[m_threshold_idx] * 0.5;
-  const double neg_half_T = m_threshold_arr[m_threshold_idx] * -0.5;
-  const auto tmp = d2_type{neg_half_T, half_T};
-
-  //for (size_t i = 0; i < num_bits; i++)
-  //  m_coeff_buf[m_LSP_old[i]] += tmp[m_bit_buffer[m_bit_idx + i]];
-  //m_bit_idx += num_bits;
-  //if (m_bit_idx >= m_budget)
-  //  return RTNType::BitBudgetMet;
+  const auto tmp =
+      d2_type{m_threshold_arr[m_threshold_idx] * -0.5, m_threshold_arr[m_threshold_idx] * 0.5};
 
   for (size_t i = 0; i < m_LSP_mask.size(); i++) {
     if (m_LSP_mask[i]) {

--- a/src/SPECK3D.cpp
+++ b/src/SPECK3D.cpp
@@ -80,6 +80,11 @@ auto sperr::SPECK3D::encode() -> RTNType
   std::transform(m_coeff_buf.cbegin(), m_coeff_buf.cend(), m_coeff_buf.begin(),
                  [](auto v) { return std::abs(v); });
 
+#ifndef QZ_TERM
+  // Mark every coefficient as insignificant
+  m_LSP_mask.assign(m_coeff_buf.size(), false);
+#endif
+
   // Find the maximum coefficient bit and fill the threshold array.
   // When max_coeff is between 0.0 and 1.0, std::log2(max_coeff) will become a
   // negative value. std::floor() will always find the smaller integer value,
@@ -143,12 +148,17 @@ auto sperr::SPECK3D::decode() -> RTNType
     m_budget = m_bit_buffer.size();
 #endif
 
+  m_initialize_sets_lists();
+
   // initialize coefficients to be zero, and sign array to be all positive
   const auto coeff_len = m_dims[0] * m_dims[1] * m_dims[2];
   m_coeff_buf.assign(coeff_len, 0.0);
   m_sign_array.assign(coeff_len, true);
 
-  m_initialize_sets_lists();
+#ifndef QZ_TERM
+  // Mark every coefficient as insignificant
+  m_LSP_mask.assign(m_coeff_buf.size(), false);
+#endif
 
   m_bit_idx = 0;
   m_threshold_arr[0] = std::pow(2.0, static_cast<double>(m_max_coeff_bit));
@@ -156,10 +166,9 @@ auto sperr::SPECK3D::decode() -> RTNType
                 [v = m_threshold_arr[0]]() mutable { return std::exchange(v, v * 0.5); });
 
   for (m_threshold_idx = 0; m_threshold_idx < m_threshold_arr.size(); m_threshold_idx++) {
-    auto rtn = m_sorting_pass_decode();
 
 #ifdef QZ_TERM
-    assert(rtn == RTNType::Good);
+    m_sorting_pass_decode();
     if (m_bit_idx > m_bit_buffer.size())
       return RTNType::Error;
     // This is the actual termination condition in QZ_TERM mode.
@@ -167,6 +176,7 @@ auto sperr::SPECK3D::decode() -> RTNType
     if (m_threshold_idx >= static_cast<size_t>(m_max_coeff_bit - m_qz_lev))
       break;
 #else
+    auto rtn = m_sorting_pass_decode();
     if (rtn == RTNType::BitBudgetMet)
       break;
     assert(rtn == RTNType::Good);
@@ -183,11 +193,6 @@ auto sperr::SPECK3D::decode() -> RTNType
   // We should not have more than 7 unprocessed bits left in the bit buffer!
   if (m_bit_idx > m_bit_buffer.size() || m_bit_buffer.size() - m_bit_idx >= 8)
     return RTNType::BitstreamWrongLen;
-#else
-  // If decoding finished before all newly-sig pixels are initialized, we finish them here!
-  for (auto idx : m_LSP_new)
-    m_coeff_buf[idx] = m_threshold_arr[m_threshold_idx] * 1.5;
-  m_LSP_new.clear();
 #endif
 
   // Restore coefficient signs by setting some of them negative
@@ -270,8 +275,7 @@ void sperr::SPECK3D::m_initialize_sets_lists()
 #ifndef QZ_TERM
   m_LSP_new.clear();
   m_LSP_new.reserve(m_coeff_buf.size() / 8);
-  m_LSP_old.clear();
-  m_LSP_old.reserve(m_coeff_buf.size() / 2);
+  m_LSP_mask.reserve(m_coeff_buf.size());
   m_bit_buffer.reserve(m_budget);
 #endif
 }
@@ -374,6 +378,7 @@ auto sperr::SPECK3D::m_process_P_encode(size_t loc, SigType sig, size_t& counter
 #ifdef QZ_TERM
     m_quantize_P_encode(pixel_idx);
 #else
+    m_coeff_buf[pixel_idx] -= m_threshold_arr[m_threshold_idx];
     m_LSP_new.push_back(pixel_idx);
 #endif
 
@@ -422,32 +427,36 @@ void sperr::SPECK3D::m_quantize_P_decode(size_t idx)
 
 auto sperr::SPECK3D::m_refinement_pass_encode() -> RTNType
 {
-  // First, process `m_LSP_old`.
-  //
-  // In fixed-size mode, we either process all elements in `m_LSP_old`,
-  // or process a portion of them that meets the total bit budget.
+  // First, process significant pixels previously found.
   //
   const auto tmpb = b2_type{false, true};
   const auto tmpd = d2_type{0.0, -m_threshold_arr[m_threshold_idx]};
-  const size_t n_to_process = std::min(m_LSP_old.size(), m_budget - m_bit_buffer.size());
-  for (size_t i = 0; i < n_to_process; i++) {
-    const size_t loc = m_LSP_old[i];
-    const size_t o1 = m_coeff_buf[loc] >= m_threshold_arr[m_threshold_idx];
-    m_coeff_buf[loc] += tmpd[o1];
-    m_bit_buffer.push_back(tmpb[o1]);
-  }
-  if (m_bit_buffer.size() >= m_budget)
-    return RTNType::BitBudgetMet;
 
-  // Second, process `m_LSP_new`
+  //const size_t n_to_process = std::min(m_LSP_old.size(), m_budget - m_bit_buffer.size());
+  //for (size_t i = 0; i < n_to_process; i++) {
+  //  const size_t loc = m_LSP_old[i];
+  //  const size_t o1 = m_coeff_buf[loc] >= m_threshold_arr[m_threshold_idx];
+  //  m_coeff_buf[loc] += tmpd[o1];
+  //  m_bit_buffer.push_back(tmpb[o1]);
+  //}
+  //if (m_bit_buffer.size() >= m_budget)
+  //  return RTNType::BitBudgetMet;
+
+  for (size_t i = 0; i < m_LSP_mask.size(); i++) {
+    if (m_LSP_mask[i]) {
+      const size_t o1 = m_coeff_buf[i] >= m_threshold_arr[m_threshold_idx];
+      m_coeff_buf[i] += tmpd[o1];
+      m_bit_buffer.push_back(tmpb[o1]);
+
+      if (m_bit_buffer.size() >= m_budget)
+        return RTNType::BitBudgetMet;
+    }
+  }
+
+  // Second, mark newly found significant pixels in `m_LSP_mask`.
   //
   for (auto idx : m_LSP_new)
-    m_coeff_buf[idx] -= m_threshold_arr[m_threshold_idx];
-
-  // Third, attached `m_LSP_new` to the end of `m_LSP_old`, and then clear it.
-  // (`m_LSP_old` has reserved the full coeff length capacity in advance.)
-  //
-  m_LSP_old.insert(m_LSP_old.end(), m_LSP_new.cbegin(), m_LSP_new.cend());
+    m_LSP_mask[idx] = true;
   m_LSP_new.clear();
 
   return RTNType::Good;
@@ -455,32 +464,33 @@ auto sperr::SPECK3D::m_refinement_pass_encode() -> RTNType
 
 auto sperr::SPECK3D::m_refinement_pass_decode() -> RTNType
 {
-  // First, process `m_LSP_old`
+  // First, process significant pixels previously found.
   //
-  const size_t num_bits = std::min(m_budget - m_bit_idx, m_LSP_old.size());
+  //const size_t num_bits = std::min(m_budget - m_bit_idx, m_LSP_old.size());
+  //const double one_half_T = m_threshold_arr[m_threshold_idx] * 1.5;
   const double half_T = m_threshold_arr[m_threshold_idx] * 0.5;
   const double neg_half_T = m_threshold_arr[m_threshold_idx] * -0.5;
-  const double one_half_T = m_threshold_arr[m_threshold_idx] * 1.5;
   const auto tmp = d2_type{neg_half_T, half_T};
 
-  for (size_t i = 0; i < num_bits; i++)
-    m_coeff_buf[m_LSP_old[i]] += tmp[m_bit_buffer[m_bit_idx + i]];
-  m_bit_idx += num_bits;
-  if (m_bit_idx >= m_budget)
-    return RTNType::BitBudgetMet;
+  //for (size_t i = 0; i < num_bits; i++)
+  //  m_coeff_buf[m_LSP_old[i]] += tmp[m_bit_buffer[m_bit_idx + i]];
+  //m_bit_idx += num_bits;
+  //if (m_bit_idx >= m_budget)
+  //  return RTNType::BitBudgetMet;
 
-  // Second, process `m_LSP_new`
+  for (size_t i = 0; i < m_LSP_mask.size(); i++) {
+    if (m_LSP_mask[i]) {
+      m_coeff_buf[i] += tmp[m_bit_buffer[m_bit_idx++]];
+
+      if (m_bit_idx >= m_budget)
+        return RTNType::BitBudgetMet;
+    }
+  }
+
+  // Second, mark newly found significant pixels in `m_LSP_mark`
   //
   for (auto idx : m_LSP_new)
-    m_coeff_buf[idx] = one_half_T;
-
-  // Third, attached `m_LSP_new` to the end of `m_LSP_old`.
-  // (`m_LSP_old` has reserved the full coeff length capacity in advance.)
-  //
-  m_LSP_old.insert(m_LSP_old.end(), m_LSP_new.cbegin(), m_LSP_new.cend());
-
-  // Fourth, clear `m_LSP_new`.
-  //
+    m_LSP_mask[idx] = true;
   m_LSP_new.clear();
 
   return RTNType::Good;
@@ -612,6 +622,7 @@ auto sperr::SPECK3D::m_process_P_decode(size_t loc, size_t& counter, bool read) 
 #ifdef QZ_TERM
     m_quantize_P_decode(pixel_idx);
 #else
+    m_coeff_buf[pixel_idx] = m_threshold_arr[m_threshold_idx] * 1.5;
     m_LSP_new.push_back(pixel_idx);
 #endif
 

--- a/test_scripts/speck2d_unit_test.cpp
+++ b/test_scripts/speck2d_unit_test.cpp
@@ -161,8 +161,8 @@ TEST(speck2d, lena)
   tester.execute(4.0);
   auto psnr = tester.get_psnr();
   auto lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 54.2790);
-  EXPECT_LT(psnr, 54.2791);
+  EXPECT_GT(psnr, 54.2788);
+  EXPECT_LT(psnr, 54.2789);
   EXPECT_LT(lmax, 2.2361);
 
   tester.execute(2.0);
@@ -208,8 +208,8 @@ TEST(speck2d, odd_dim_image)
   tester.execute(1.0);
   psnr = tester.get_psnr();
   lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 39.8890);
-  EXPECT_LT(psnr, 39.8891);
+  EXPECT_GT(psnr, 39.8916);
+  EXPECT_LT(psnr, 39.8917);
   EXPECT_LT(lmax, 6.43229);
 
   tester.execute(0.5f);

--- a/test_scripts/speck3d_unit_test.cpp
+++ b/test_scripts/speck3d_unit_test.cpp
@@ -21,9 +21,9 @@ class speck_tester {
     m_dims = dims;
   }
 
-  [[nodiscard]] float get_psnr() const { return m_psnr; }
+  float get_psnr() const { return m_psnr; }
 
-  [[nodiscard]] float get_lmax() const { return m_lmax; }
+  float get_lmax() const { return m_lmax; }
 
   //
   // Execute the compression/decompression pipeline. Return 0 on success
@@ -365,8 +365,8 @@ TEST(speck3d_bit_rate, small)
   tester.execute(1.0);
   psnr = tester.get_psnr();
   lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 35.0252);
-  EXPECT_LT(psnr, 35.0253);
+  EXPECT_GT(psnr, 35.0593);
+  EXPECT_LT(psnr, 35.0594);
   EXPECT_LT(lmax, 12.0156);
 }
 
@@ -424,8 +424,8 @@ TEST(speck3d_bit_rate, narrow_data_range)
   tester.execute(1.0);
   psnr = tester.get_psnr();
   lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 49.7755);
-  EXPECT_LT(psnr, 49.7756);
+  EXPECT_GT(psnr, 49.7494);
+  EXPECT_LT(psnr, 49.7495);
   EXPECT_LT(lmax, 1.0023e-05);
 
   tester.execute(0.5);
@@ -450,15 +450,15 @@ TEST(speck3d_bit_rate_omp, narrow_data_range)
   tester.execute(4.0);
   float psnr = tester.get_psnr();
   float lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 67.8170);
-  EXPECT_LT(psnr, 67.8171);
-  EXPECT_LT(lmax, 1.108655e-06);
+  EXPECT_GT(psnr, 67.8000);
+  EXPECT_LT(psnr, 67.80005);
+  EXPECT_LT(lmax, 1.175035e-06);
 
   tester.execute(1.0);
   psnr = tester.get_psnr();
   lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 48.9054);
-  EXPECT_LT(psnr, 48.9055);
+  EXPECT_GT(psnr, 48.9001);
+  EXPECT_LT(psnr, 48.9002);
   EXPECT_LT(lmax, 1.396333e-05);
 }
 
@@ -469,8 +469,8 @@ TEST(speck3d_bit_rate_omp, big)
   tester.execute(2.0);
   float psnr = tester.get_psnr();
   float lmax = tester.get_lmax();
-  EXPECT_GT(psnr, 53.8087);
-  EXPECT_LT(psnr, 53.8088);
+  EXPECT_GT(psnr, 53.8137);
+  EXPECT_LT(psnr, 53.8138);
   EXPECT_LT(lmax, 7.6953269e+00);
 
   tester.execute(1.0);


### PR DESCRIPTION
Changes the algorithm in fixed-size mode to have a (hopefully) big performance improvement. 
It mainly avoids the random memory access that occurs in the `refinement_pass`.

Profiler results confirm this improvement. The following graph is from VTune, where it shows the memory bandwidth utilization before and after this PR. Clearly, the program is less demanding on memory bandwidth after this PR. The runtime improvement is around 20%. 

Before PR:
<img width="1382" alt="Screen Shot 2022-05-20 at 12 33 59 PM" src="https://user-images.githubusercontent.com/814885/169593438-84614df0-92cc-4516-b416-e885f65cb806.png">


After PR:
<img width="1391" alt="Screen Shot 2022-05-20 at 12 34 27 PM" src="https://user-images.githubusercontent.com/814885/169593470-22673719-42d1-479c-a590-edf0fbda6f31.png">

