### PR TITLE
Rename

### DIFF
--- a/.github/workflows/clang-tidy-qz.yml
+++ b/.github/workflows/clang-tidy-qz.yml
@@ -22,4 +22,4 @@ jobs:
         builddir: 'build'
         excludedirs: ''
         extensions: 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
-        cmakeoptions: '-DBUILD_UNIT_TESTS=OFF -DQZ_TERM=ON'
+        cmakeoptions: '-DBUILD_UNIT_TESTS=OFF -DQZ_TERM=ON -DUSE_ZSTD=OFF'

--- a/.github/workflows/clang-tidy-size.yml
+++ b/.github/workflows/clang-tidy-size.yml
@@ -22,4 +22,4 @@ jobs:
         builddir: 'build'
         excludedirs: ''
         extensions: 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
-        cmakeoptions: '-DBUILD_UNIT_TESTS=OFF -DQZ_TERM=OFF'
+        cmakeoptions: '-DBUILD_UNIT_TESTS=OFF -DQZ_TERM=OFF -DUSE_ZSTD=OFF'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,8 +63,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: |
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DUSE_ZSTD=OFF
+    - run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DUSE_ZSTD=OFF
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,10 +53,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-      with:
-        cmakeoptions: '-DBUILD_UNIT_TESTS=OFF -DBUILD_CLI_UTILITIES=OFF -DQZ_TERM=ON -DUSE_ZSTD=OFF'
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -65,9 +63,8 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DUSE_ZSTD=OFF
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,6 +55,8 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v1
+      with:
+        cmakeoptions: '-DBUILD_UNIT_TESTS=OFF -DBUILD_CLI_UTILITIES=OFF -DQZ_TERM=ON -DUSE_ZSTD=OFF'
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/unit-test-qz.yml
+++ b/.github/workflows/unit-test-qz.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DUSE_ZSTD=OFF
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/unit-test-size.yml
+++ b/.github/workflows/unit-test-size.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DQZ_TERM=${{env.QZ_TERM}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DQZ_TERM=${{env.QZ_TERM}} -DUSE_ZSTD=OFF
 
     - name: Build
       # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 option( BUILD_UNIT_TESTS "Build unit tests using GoogleTest" ON )
 option( BUILD_CLI_UTILITIES "Build a set of command line utilities" ON )
-option( USE_ZSTD "Incorporate ZSTD to achieve further 5% reduction" OFF )
+option( USE_ZSTD "Incorporate ZSTD to achieve further reduction (~5%) in fixed-error mode" ON )
 option( USE_OMP "Use OpenMP parallelization on 3D volumes" ON )
 option( QZ_TERM  "Coding terminates by quantization level" ON )
 option( BUILD_SHARED_LIBS "Build shared SPERR library" ON )

--- a/include/SPERR2D_Compressor.h
+++ b/include/SPERR2D_Compressor.h
@@ -3,8 +3,8 @@
 // it provides easy-to-use APIs.
 //
 
-#ifndef SPECK2D_COMPRESSOR_H
-#define SPECK2D_COMPRESSOR_H
+#ifndef SPERR2D_COMPRESSOR_H
+#define SPERR2D_COMPRESSOR_H
 
 #include "CDF97.h"
 #include "Conditioner.h"
@@ -16,7 +16,7 @@
 
 using sperr::RTNType;
 
-class SPECK2D_Compressor {
+class SPERR2D_Compressor {
  public:
   // Accept incoming data: copy from a raw memory block
   template <typename T>
@@ -47,7 +47,7 @@ class SPECK2D_Compressor {
  private:
   sperr::dims_type m_dims = {0, 0, 0};
   sperr::vecd_type m_val_buf;
-  const size_t m_meta_size = 10; // Need to be the same as in SPECK2D_Decompressor.h
+  const size_t m_meta_size = 10; // Need to be the same as in SPERR2D_Decompressor.h
 
 #ifdef QZ_TERM
   sperr::vec8_type m_sperr_stream;

--- a/include/SPERR2D_Decompressor.h
+++ b/include/SPERR2D_Decompressor.h
@@ -4,8 +4,8 @@
 // Functionality wise, it does not bring anything new though.
 //
 
-#ifndef SPECK2D_DECOMPRESSOR_H
-#define SPECK2D_DECOMPRESSOR_H
+#ifndef SPERR2D_DECOMPRESSOR_H
+#define SPERR2D_DECOMPRESSOR_H
 
 #include "CDF97.h"
 #include "Conditioner.h"
@@ -17,7 +17,7 @@
 
 using sperr::RTNType;
 
-class SPECK2D_Decompressor {
+class SPERR2D_Decompressor {
  public:
   // Accept incoming data.
   auto use_bitstream(const void* p, size_t len) -> RTNType;
@@ -40,7 +40,7 @@ class SPECK2D_Decompressor {
   sperr::Conditioner::meta_type m_condi_stream;
   sperr::vec8_type m_speck_stream;
   sperr::vecd_type m_val_buf;
-  const size_t m_meta_size = 10; // Need to be the same as in SPECK2D_Compressor.h
+  const size_t m_meta_size = 10; // Need to be the same as in SPERR2D_Compressor.h
 
 #ifdef QZ_TERM
   sperr::SPERR m_sperr;

--- a/include/SPERR3D_Compressor.h
+++ b/include/SPERR3D_Compressor.h
@@ -1,5 +1,5 @@
-#ifndef SPECK3D_COMPRESSOR_H
-#define SPECK3D_COMPRESSOR_H
+#ifndef SPERR3D_COMPRESSOR_H
+#define SPERR3D_COMPRESSOR_H
 
 #include "CDF97.h"
 #include "Conditioner.h"
@@ -15,7 +15,7 @@
 
 namespace sperr {
 
-class SPECK3D_Compressor {
+class SPERR3D_Compressor {
  public:
   // Accept incoming data: copy from a raw memory block
   template <typename T>

--- a/include/SPERR3D_Decompressor.h
+++ b/include/SPERR3D_Decompressor.h
@@ -4,8 +4,8 @@
 // Functionality wise, it does not bring anything new though.
 //
 
-#ifndef SPECK3D_DECOMPRESSOR_H
-#define SPECK3D_DECOMPRESSOR_H
+#ifndef SPERR3D_DECOMPRESSOR_H
+#define SPERR3D_DECOMPRESSOR_H
 
 #include "CDF97.h"
 #include "Conditioner.h"
@@ -21,7 +21,7 @@
 
 namespace sperr {
 
-class SPECK3D_Decompressor {
+class SPERR3D_Decompressor {
  public:
   // Accept incoming data.
   auto use_bitstream(const void* p, size_t len) -> RTNType;

--- a/include/SPERR3D_OMP_C.h
+++ b/include/SPERR3D_OMP_C.h
@@ -1,17 +1,17 @@
 //
-// This is a class that performs SPECK3D compression, and also utilizes OpenMP
+// This is a class that performs SPERR3D compression, and also utilizes OpenMP
 // to achieve parallelization: the input volume is divided into smaller chunks
 // and then they're processed individually.
 //
 
-#ifndef SPECK3D_OMP_C_H
-#define SPECK3D_OMP_C_H
+#ifndef SPERR3D_OMP_C_H
+#define SPERR3D_OMP_C_H
 
-#include "SPECK3D_Compressor.h"
+#include "SPERR3D_Compressor.h"
 
 using sperr::RTNType;
 
-class SPECK3D_OMP_C {
+class SPERR3D_OMP_C {
  public:
   void set_num_threads(size_t);
 

--- a/include/SPERR3D_OMP_D.h
+++ b/include/SPERR3D_OMP_D.h
@@ -1,18 +1,18 @@
 //
-// This is a class that performs SPECK3D decompression, and also utilizes OpenMP
+// This is a class that performs SPERR3D decompression, and also utilizes OpenMP
 // to achieve parallelization: input to this class is supposed to be smaller
 // chunks of a bigger volume, and each chunk is decompressed individually before
 // returning back the big volume.
 //
 
-#ifndef SPECK3D_OMP_D_H
-#define SPECK3D_OMP_D_H
+#ifndef SPERR3D_OMP_D_H
+#define SPERR3D_OMP_D_H
 
-#include "SPECK3D_Decompressor.h"
+#include "SPERR3D_Decompressor.h"
 
 using sperr::RTNType;
 
-class SPECK3D_OMP_D {
+class SPERR3D_OMP_D {
  public:
   // Parse the header of this stream, and stores the pointer.
   auto use_bitstream(const void*, size_t) -> RTNType;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,10 +7,10 @@ add_library( SPERR
              SPECK2D.cpp
              SPECK3D.cpp
              SPERR.cpp
-             SPECK3D_Compressor.cpp
-             SPECK3D_Decompressor.cpp
-             SPECK3D_OMP_C.cpp
-             SPECK3D_OMP_D.cpp
+             SPERR3D_Compressor.cpp
+             SPERR3D_Decompressor.cpp
+             SPERR3D_OMP_C.cpp
+             SPERR3D_OMP_D.cpp
              SPERR2D_Compressor.cpp
              SPERR2D_Decompressor.cpp
              SPERR_C_API.cpp)
@@ -37,10 +37,10 @@ set_target_properties( SPERR PROPERTIES VERSION ${SPERR_VERSION} )
 #
 set( public_h_list 
 "include/sperr_helper.h;\
-include/SPECK3D_Compressor.h;\
-include/SPECK3D_Decompressor.h;\
-include/SPECK3D_OMP_C.h;\
-include/SPECK3D_OMP_D.h;\
+include/SPERR3D_Compressor.h;\
+include/SPERR3D_Decompressor.h;\
+include/SPERR3D_OMP_C.h;\
+include/SPERR3D_OMP_D.h;\
 include/SPERR2D_Compressor.h;\
 include/SPERR2D_Decompressor.h;\
 include/Conditioner.h;\

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,8 +11,8 @@ add_library( SPERR
              SPECK3D_Decompressor.cpp
              SPECK3D_OMP_C.cpp
              SPECK3D_OMP_D.cpp
-             SPECK2D_Compressor.cpp
-             SPECK2D_Decompressor.cpp
+             SPERR2D_Compressor.cpp
+             SPERR2D_Decompressor.cpp
              SPERR_C_API.cpp)
 target_include_directories( SPERR PUBLIC ${CMAKE_SOURCE_DIR}/include )
 
@@ -41,8 +41,8 @@ include/SPECK3D_Compressor.h;\
 include/SPECK3D_Decompressor.h;\
 include/SPECK3D_OMP_C.h;\
 include/SPECK3D_OMP_D.h;\
-include/SPECK2D_Compressor.h;\
-include/SPECK2D_Decompressor.h;\
+include/SPERR2D_Compressor.h;\
+include/SPERR2D_Decompressor.h;\
 include/Conditioner.h;\
 include/Analyzer.h;\
 include/CDF97.h;\

--- a/src/SPERR2D_Compressor.cpp
+++ b/src/SPERR2D_Compressor.cpp
@@ -1,4 +1,4 @@
-#include "SPECK2D_Compressor.h"
+#include "SPERR2D_Compressor.h"
 
 #include <cassert>
 #include <cstring>
@@ -8,7 +8,7 @@
 #endif
 
 template <typename T>
-auto SPECK2D_Compressor::copy_data(const T* p, size_t len, sperr::dims_type dims) -> RTNType
+auto SPERR2D_Compressor::copy_data(const T* p, size_t len, sperr::dims_type dims) -> RTNType
 {
   static_assert(std::is_floating_point<T>::value, "!! Only floating point values are supported !!");
 
@@ -21,10 +21,10 @@ auto SPECK2D_Compressor::copy_data(const T* p, size_t len, sperr::dims_type dims
 
   return RTNType::Good;
 }
-template auto SPECK2D_Compressor::copy_data(const double*, size_t, sperr::dims_type) -> RTNType;
-template auto SPECK2D_Compressor::copy_data(const float*, size_t, sperr::dims_type) -> RTNType;
+template auto SPERR2D_Compressor::copy_data(const double*, size_t, sperr::dims_type) -> RTNType;
+template auto SPERR2D_Compressor::copy_data(const float*, size_t, sperr::dims_type) -> RTNType;
 
-auto SPECK2D_Compressor::take_data(std::vector<double>&& buf, sperr::dims_type dims) -> RTNType
+auto SPERR2D_Compressor::take_data(std::vector<double>&& buf, sperr::dims_type dims) -> RTNType
 {
   if (buf.size() != dims[0] * dims[1] || dims[2] != 1)
     return RTNType::WrongDims;
@@ -36,20 +36,20 @@ auto SPECK2D_Compressor::take_data(std::vector<double>&& buf, sperr::dims_type d
 }
 
 #ifdef QZ_TERM
-void SPECK2D_Compressor::set_qz_level(int32_t q)
+void SPERR2D_Compressor::set_qz_level(int32_t q)
 {
   m_qz_lev = q;
 }
-void SPECK2D_Compressor::set_tolerance(double tol)
+void SPERR2D_Compressor::set_tolerance(double tol)
 {
   m_tol = tol;
 }
-auto SPECK2D_Compressor::get_outlier_stats() const -> std::pair<size_t, size_t>
+auto SPERR2D_Compressor::get_outlier_stats() const -> std::pair<size_t, size_t>
 {
   return {m_LOS.size(), m_sperr_stream.size()};
 }
 #else
-auto SPECK2D_Compressor::set_bpp(double bpp) -> RTNType
+auto SPERR2D_Compressor::set_bpp(double bpp) -> RTNType
 {
   const auto total_vals = m_dims[0] * m_dims[1];
   if (bpp <= 0.0 || bpp > 64.0)
@@ -63,22 +63,22 @@ auto SPECK2D_Compressor::set_bpp(double bpp) -> RTNType
 }
 #endif
 
-void SPECK2D_Compressor::toggle_conditioning(sperr::Conditioner::settings_type settings)
+void SPERR2D_Compressor::toggle_conditioning(sperr::Conditioner::settings_type settings)
 {
   m_conditioning_settings = settings;
 }
 
-auto SPECK2D_Compressor::view_encoded_bitstream() const -> const std::vector<uint8_t>&
+auto SPERR2D_Compressor::view_encoded_bitstream() const -> const std::vector<uint8_t>&
 {
   return m_encoded_stream;
 }
 
-auto SPECK2D_Compressor::release_encoded_bitstream() -> std::vector<uint8_t>&&
+auto SPERR2D_Compressor::release_encoded_bitstream() -> std::vector<uint8_t>&&
 {
   return std::move(m_encoded_stream);
 }
 
-auto SPECK2D_Compressor::compress() -> RTNType
+auto SPERR2D_Compressor::compress() -> RTNType
 {
   const auto total_vals = m_dims[0] * m_dims[1];
   if (m_val_buf.empty() || m_val_buf.size() != total_vals)
@@ -197,7 +197,7 @@ auto SPECK2D_Compressor::compress() -> RTNType
   return rtn;
 }
 
-auto SPECK2D_Compressor::m_assemble_encoded_bitstream() -> RTNType
+auto SPERR2D_Compressor::m_assemble_encoded_bitstream() -> RTNType
 {
   // This method does 3 things:
   // 1) prepend a proper header containing meta data.
@@ -205,7 +205,7 @@ auto SPECK2D_Compressor::m_assemble_encoded_bitstream() -> RTNType
   // 3) potentially apply ZSTD on the entire memory block except the meta data.
 
   // Meta data definition:
-  // the 1st byte records the current major version of SPECK,
+  // the 1st byte records the current major version of SPERR,
   // the 2nd byte records 8 booleans, with their meanings documented below, and
   // the next 8 bytes record X and Y dimension, 4 bytes each (in uint32_t type).
   //

--- a/src/SPERR2D_Decompressor.cpp
+++ b/src/SPERR2D_Decompressor.cpp
@@ -1,4 +1,4 @@
-#include "SPECK2D_Decompressor.h"
+#include "SPERR2D_Decompressor.h"
 
 #include <cassert>
 #include <cstring>
@@ -7,7 +7,7 @@
 #include "zstd.h"
 #endif
 
-auto SPECK2D_Decompressor::use_bitstream(const void* p, size_t len) -> RTNType
+auto SPERR2D_Decompressor::use_bitstream(const void* p, size_t len) -> RTNType
 {
   // This method parses the metadata of a bitstream and performs the following tasks:
   // 1) Verify if the major version number is consistant.
@@ -133,7 +133,7 @@ auto SPECK2D_Decompressor::use_bitstream(const void* p, size_t len) -> RTNType
 }
 
 #ifndef QZ_TERM
-auto SPECK2D_Decompressor::set_bpp(double bpp) -> RTNType
+auto SPERR2D_Decompressor::set_bpp(double bpp) -> RTNType
 {
   if (bpp < 0.0 || bpp > 64.0)
     return RTNType::InvalidParam;
@@ -145,33 +145,33 @@ auto SPECK2D_Decompressor::set_bpp(double bpp) -> RTNType
 #endif
 
 template <typename T>
-auto SPECK2D_Decompressor::get_data() const -> std::vector<T>
+auto SPERR2D_Decompressor::get_data() const -> std::vector<T>
 {
   auto out_buf = std::vector<T>(m_val_buf.size());
   std::copy(m_val_buf.begin(), m_val_buf.end(), out_buf.begin());
 
   return out_buf;
 }
-template auto SPECK2D_Decompressor::get_data() const -> std::vector<double>;
-template auto SPECK2D_Decompressor::get_data() const -> std::vector<float>;
+template auto SPERR2D_Decompressor::get_data() const -> std::vector<double>;
+template auto SPERR2D_Decompressor::get_data() const -> std::vector<float>;
 
-auto SPECK2D_Decompressor::view_data() const -> const std::vector<double>&
+auto SPERR2D_Decompressor::view_data() const -> const std::vector<double>&
 {
   return m_val_buf;
 }
 
-auto SPECK2D_Decompressor::release_data() -> std::vector<double>&&
+auto SPERR2D_Decompressor::release_data() -> std::vector<double>&&
 {
   m_dims = {0, 0, 0};
   return std::move(m_val_buf);
 }
 
-auto SPECK2D_Decompressor::get_dims() const -> std::array<size_t, 3>
+auto SPERR2D_Decompressor::get_dims() const -> std::array<size_t, 3>
 {
   return m_dims;
 }
 
-auto SPECK2D_Decompressor::decompress() -> RTNType
+auto SPERR2D_Decompressor::decompress() -> RTNType
 {
   // `m_condi_stream` might be indicating a constant field, so let's test and handle that case.
   auto [constant, const_val, nconst_vals] = m_conditioner.parse_constant(m_condi_stream);

--- a/src/SPERR3D_Compressor.cpp
+++ b/src/SPERR3D_Compressor.cpp
@@ -1,10 +1,10 @@
-#include "SPECK3D_Compressor.h"
+#include "SPERR3D_Compressor.h"
 
 #include <cassert>
 #include <cstring>
 
 template <typename T>
-auto sperr::SPECK3D_Compressor::copy_data(const T* p, size_t len, sperr::dims_type dims) -> RTNType
+auto sperr::SPERR3D_Compressor::copy_data(const T* p, size_t len, sperr::dims_type dims) -> RTNType
 {
   static_assert(std::is_floating_point<T>::value, "!! Only floating point values are supported !!");
 
@@ -18,10 +18,10 @@ auto sperr::SPECK3D_Compressor::copy_data(const T* p, size_t len, sperr::dims_ty
 
   return RTNType::Good;
 }
-template auto sperr::SPECK3D_Compressor::copy_data(const double*, size_t, dims_type) -> RTNType;
-template auto sperr::SPECK3D_Compressor::copy_data(const float*, size_t, dims_type) -> RTNType;
+template auto sperr::SPERR3D_Compressor::copy_data(const double*, size_t, dims_type) -> RTNType;
+template auto sperr::SPERR3D_Compressor::copy_data(const float*, size_t, dims_type) -> RTNType;
 
-auto sperr::SPECK3D_Compressor::take_data(sperr::vecd_type&& buf, sperr::dims_type dims) -> RTNType
+auto sperr::SPERR3D_Compressor::take_data(sperr::vecd_type&& buf, sperr::dims_type dims) -> RTNType
 {
   if (buf.size() != dims[0] * dims[1] * dims[2])
     return RTNType::WrongDims;
@@ -32,18 +32,18 @@ auto sperr::SPECK3D_Compressor::take_data(sperr::vecd_type&& buf, sperr::dims_ty
   return RTNType::Good;
 }
 
-auto sperr::SPECK3D_Compressor::view_encoded_bitstream() const -> const std::vector<uint8_t>&
+auto sperr::SPERR3D_Compressor::view_encoded_bitstream() const -> const std::vector<uint8_t>&
 {
   return m_encoded_stream;
 }
 
-auto sperr::SPECK3D_Compressor::release_encoded_bitstream() -> std::vector<uint8_t>&&
+auto sperr::SPERR3D_Compressor::release_encoded_bitstream() -> std::vector<uint8_t>&&
 {
   return std::move(m_encoded_stream);
 }
 
 #ifdef QZ_TERM
-auto sperr::SPECK3D_Compressor::compress() -> RTNType
+auto sperr::SPERR3D_Compressor::compress() -> RTNType
 {
   const auto total_vals = m_dims[0] * m_dims[1] * m_dims[2];
   if (m_val_buf.empty() || m_val_buf.size() != total_vals)
@@ -89,7 +89,7 @@ auto sperr::SPECK3D_Compressor::compress() -> RTNType
   if (rtn != RTNType::Good)
     return rtn;
   // Figure out which dwt3d strategy to use.
-  // Note: this strategy needs to be consistent with SPECK3D_Decompressor.
+  // Note: this strategy needs to be consistent with SPERR3D_Decompressor.
   auto xforms_xy = sperr::num_of_xforms(std::min(m_dims[0], m_dims[1]));
   auto xforms_z = sperr::num_of_xforms(m_dims[2]);
   if (xforms_xy == xforms_z)
@@ -175,7 +175,7 @@ auto sperr::SPECK3D_Compressor::compress() -> RTNType
 //
 // Start fixed-size mode
 //
-auto sperr::SPECK3D_Compressor::compress() -> RTNType
+auto sperr::SPERR3D_Compressor::compress() -> RTNType
 {
   const auto total_vals = m_dims[0] * m_dims[1] * m_dims[2];
   if (m_val_buf.empty() || m_val_buf.size() != total_vals)
@@ -204,7 +204,7 @@ auto sperr::SPECK3D_Compressor::compress() -> RTNType
   if (rtn != RTNType::Good)
     return rtn;
   // Figure out which dwt3d strategy to use.
-  // Note: this strategy needs to be consistent with SPECK3D_Decompressor.
+  // Note: this strategy needs to be consistent with SPERR3D_Decompressor.
   auto xforms_xy = sperr::num_of_xforms(std::min(m_dims[0], m_dims[1]));
   auto xforms_z = sperr::num_of_xforms(m_dims[2]);
   if (xforms_xy == xforms_z)
@@ -232,7 +232,7 @@ auto sperr::SPECK3D_Compressor::compress() -> RTNType
 #endif
 
 #ifdef USE_ZSTD
-auto sperr::SPECK3D_Compressor::m_assemble_encoded_bitstream() -> RTNType
+auto sperr::SPERR3D_Compressor::m_assemble_encoded_bitstream() -> RTNType
 {
 #ifdef QZ_TERM
   const size_t total_size = m_condi_stream.size() + m_speck_stream.size() + m_sperr_stream.size();
@@ -281,7 +281,7 @@ auto sperr::SPECK3D_Compressor::m_assemble_encoded_bitstream() -> RTNType
 //
 // Start the no-ZSTD case
 //
-auto sperr::SPECK3D_Compressor::m_assemble_encoded_bitstream() -> RTNType
+auto sperr::SPERR3D_Compressor::m_assemble_encoded_bitstream() -> RTNType
 {
 #ifdef QZ_TERM
   const size_t total_size = m_condi_stream.size() + m_speck_stream.size() + m_sperr_stream.size();
@@ -305,20 +305,20 @@ auto sperr::SPECK3D_Compressor::m_assemble_encoded_bitstream() -> RTNType
 #endif
 
 #ifdef QZ_TERM
-void sperr::SPECK3D_Compressor::set_qz_level(int32_t q)
+void sperr::SPERR3D_Compressor::set_qz_level(int32_t q)
 {
   m_qz_lev = q;
 }
-void sperr::SPECK3D_Compressor::set_tolerance(double tol)
+void sperr::SPERR3D_Compressor::set_tolerance(double tol)
 {
   m_tol = tol;
 }
-auto sperr::SPECK3D_Compressor::get_outlier_stats() const -> std::pair<size_t, size_t>
+auto sperr::SPERR3D_Compressor::get_outlier_stats() const -> std::pair<size_t, size_t>
 {
   return {m_LOS.size(), m_sperr_stream.size()};
 }
 #else
-auto sperr::SPECK3D_Compressor::set_bpp(double bpp) -> RTNType
+auto sperr::SPERR3D_Compressor::set_bpp(double bpp) -> RTNType
 {
   const auto total_vals = m_dims[0] * m_dims[1] * m_dims[2];
   if (bpp < 0.0 || bpp > 64.0)
@@ -332,7 +332,7 @@ auto sperr::SPECK3D_Compressor::set_bpp(double bpp) -> RTNType
 }
 #endif
 
-void sperr::SPECK3D_Compressor::toggle_conditioning(sperr::Conditioner::settings_type b4)
+void sperr::SPERR3D_Compressor::toggle_conditioning(sperr::Conditioner::settings_type b4)
 {
   m_conditioning_settings = b4;
 }

--- a/src/SPERR3D_Decompressor.cpp
+++ b/src/SPERR3D_Decompressor.cpp
@@ -1,9 +1,9 @@
-#include "SPECK3D_Decompressor.h"
+#include "SPERR3D_Decompressor.h"
 
 #include <cassert>
 #include <cstring>
 
-auto sperr::SPECK3D_Decompressor::use_bitstream(const void* p, size_t len) -> RTNType
+auto sperr::SPERR3D_Decompressor::use_bitstream(const void* p, size_t len) -> RTNType
 {
   // It'd be bad to have some buffers updated, and some others not.
   // So let's clean up everything at the very beginning of this routine
@@ -90,13 +90,13 @@ auto sperr::SPECK3D_Decompressor::use_bitstream(const void* p, size_t len) -> RT
   return RTNType::Good;
 }
 
-void sperr::SPECK3D_Decompressor::set_dims(dims_type dims)
+void sperr::SPERR3D_Decompressor::set_dims(dims_type dims)
 {
   m_dims = dims;
 }
 
 #ifndef QZ_TERM
-auto sperr::SPECK3D_Decompressor::set_bpp(double bpp) -> RTNType
+auto sperr::SPERR3D_Decompressor::set_bpp(double bpp) -> RTNType
 {
   if (bpp < 0.0 || bpp > 64.0)
     return RTNType::InvalidParam;
@@ -107,7 +107,7 @@ auto sperr::SPECK3D_Decompressor::set_bpp(double bpp) -> RTNType
 }
 #endif
 
-auto sperr::SPECK3D_Decompressor::decompress() -> RTNType
+auto sperr::SPERR3D_Decompressor::decompress() -> RTNType
 {
   // `m_condi_stream` might be indicating a constant field, so let's see if that's
   // the case, and if it is, we don't need to go through dwt and speck stuff anymore.
@@ -142,7 +142,7 @@ auto sperr::SPECK3D_Decompressor::decompress() -> RTNType
   const auto& decoder_out = m_decoder.view_data();
   m_cdf.copy_data(decoder_out.data(), decoder_out.size(), m_dims);
   // Figure out which dwt3d strategy to use.
-  // Note: this strategy needs to be consistent with SPECK3D_Compressor.
+  // Note: this strategy needs to be consistent with SPERR3D_Compressor.
   auto xforms_xy = sperr::num_of_xforms(std::min(m_dims[0], m_dims[1]));
   auto xforms_z = sperr::num_of_xforms(m_dims[2]);
   if (xforms_xy == xforms_z)
@@ -177,22 +177,22 @@ auto sperr::SPECK3D_Decompressor::decompress() -> RTNType
 }
 
 template <typename T>
-auto sperr::SPECK3D_Decompressor::get_data() const -> std::vector<T>
+auto sperr::SPERR3D_Decompressor::get_data() const -> std::vector<T>
 {
   auto out_buf = std::vector<T>(m_val_buf.size());
   std::copy(m_val_buf.begin(), m_val_buf.end(), out_buf.begin());
 
   return out_buf;
 }
-template auto sperr::SPECK3D_Decompressor::get_data() const -> std::vector<double>;
-template auto sperr::SPECK3D_Decompressor::get_data() const -> std::vector<float>;
+template auto sperr::SPERR3D_Decompressor::get_data() const -> std::vector<double>;
+template auto sperr::SPERR3D_Decompressor::get_data() const -> std::vector<float>;
 
-auto sperr::SPECK3D_Decompressor::view_data() const -> const std::vector<double>&
+auto sperr::SPERR3D_Decompressor::view_data() const -> const std::vector<double>&
 {
   return m_val_buf;
 }
 
-auto sperr::SPECK3D_Decompressor::release_data() -> std::vector<double>&&
+auto sperr::SPERR3D_Decompressor::release_data() -> std::vector<double>&&
 {
   m_dims = {0, 0, 0};
   return std::move(m_val_buf);

--- a/src/SPERR3D_OMP_C.cpp
+++ b/src/SPERR3D_OMP_C.cpp
@@ -1,4 +1,4 @@
-#include "SPECK3D_OMP_C.h"
+#include "SPERR3D_OMP_C.h"
 
 #include <algorithm>  // std::all_of()
 #include <cassert>
@@ -9,27 +9,27 @@
 #include <omp.h>
 #endif
 
-void SPECK3D_OMP_C::set_num_threads(size_t n)
+void SPERR3D_OMP_C::set_num_threads(size_t n)
 {
   if (n > 0)
     m_num_threads = n;
 }
 
-void SPECK3D_OMP_C::toggle_conditioning(sperr::Conditioner::settings_type b4)
+void SPERR3D_OMP_C::toggle_conditioning(sperr::Conditioner::settings_type b4)
 {
   m_conditioning_settings = b4;
 }
 
 #ifdef QZ_TERM
-void SPECK3D_OMP_C::set_qz_level(int32_t q)
+void SPERR3D_OMP_C::set_qz_level(int32_t q)
 {
   m_qz_lev = q;
 }
-void SPECK3D_OMP_C::set_tolerance(double t)
+void SPERR3D_OMP_C::set_tolerance(double t)
 {
   m_tol = t;
 }
-auto SPECK3D_OMP_C::get_outlier_stats() const -> std::pair<size_t, size_t>
+auto SPERR3D_OMP_C::get_outlier_stats() const -> std::pair<size_t, size_t>
 {
   using pair = std::pair<size_t, size_t>;
   pair sum{0, 0};
@@ -39,7 +39,7 @@ auto SPECK3D_OMP_C::get_outlier_stats() const -> std::pair<size_t, size_t>
   return std::accumulate(m_outlier_stats.begin(), m_outlier_stats.end(), sum, op);
 }
 #else
-auto SPECK3D_OMP_C::set_bpp(double bpp) -> RTNType
+auto SPERR3D_OMP_C::set_bpp(double bpp) -> RTNType
 {
   auto eq0 = [](auto v) { return v == 0; };
 
@@ -64,7 +64,7 @@ auto SPECK3D_OMP_C::set_bpp(double bpp) -> RTNType
 #endif
 
 template <typename T>
-auto SPECK3D_OMP_C::copy_data(const T* vol,
+auto SPERR3D_OMP_C::copy_data(const T* vol,
                               size_t len,
                               sperr::dims_type vol_dims,
                               sperr::dims_type chunk_dims) -> RTNType
@@ -90,12 +90,12 @@ auto SPECK3D_OMP_C::copy_data(const T* vol,
 
   return RTNType::Good;
 }
-template auto SPECK3D_OMP_C::copy_data(const float*, size_t, sperr::dims_type, sperr::dims_type)
+template auto SPERR3D_OMP_C::copy_data(const float*, size_t, sperr::dims_type, sperr::dims_type)
     -> RTNType;
-template auto SPECK3D_OMP_C::copy_data(const double*, size_t, sperr::dims_type, sperr::dims_type)
+template auto SPERR3D_OMP_C::copy_data(const double*, size_t, sperr::dims_type, sperr::dims_type)
     -> RTNType;
 
-auto SPECK3D_OMP_C::compress() -> RTNType
+auto SPERR3D_OMP_C::compress() -> RTNType
 {
   // Need to make sure that the chunks are ready!
   auto chunks = sperr::chunk_volume(m_dims, m_chunk_dims);
@@ -107,7 +107,7 @@ auto SPECK3D_OMP_C::compress() -> RTNType
     return RTNType::Error;
 
   // Let's prepare some data structures for compression!
-  auto compressors = std::vector<sperr::SPECK3D_Compressor>(m_num_threads);
+  auto compressors = std::vector<sperr::SPERR3D_Compressor>(m_num_threads);
   auto chunk_rtn = std::vector<RTNType>(num_chunks, RTNType::Good);
   m_encoded_streams.resize(num_chunks);
   std::for_each(m_encoded_streams.begin(), m_encoded_streams.end(), [](auto& v) { v.clear(); });
@@ -159,7 +159,7 @@ auto SPECK3D_OMP_C::compress() -> RTNType
   return RTNType::Good;
 }
 
-auto SPECK3D_OMP_C::get_encoded_bitstream() const -> std::vector<uint8_t>
+auto SPERR3D_OMP_C::get_encoded_bitstream() const -> std::vector<uint8_t>
 {
   auto buf = std::vector<uint8_t>();
   auto header = m_generate_header();
@@ -181,7 +181,7 @@ auto SPECK3D_OMP_C::get_encoded_bitstream() const -> std::vector<uint8_t>
   return buf;
 }
 
-auto SPECK3D_OMP_C::m_generate_header() const -> sperr::vec8_type
+auto SPERR3D_OMP_C::m_generate_header() const -> sperr::vec8_type
 {
   // The header would contain the following information
   //  -- a version number                     (1 byte)

--- a/src/SPERR3D_OMP_D.cpp
+++ b/src/SPERR3D_OMP_D.cpp
@@ -1,5 +1,5 @@
 
-#include "SPECK3D_OMP_D.h"
+#include "SPERR3D_OMP_D.h"
 
 #include <algorithm>
 #include <cassert>
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef QZ_TERM
-auto SPECK3D_OMP_D::set_bpp(double bpp) -> RTNType
+auto SPERR3D_OMP_D::set_bpp(double bpp) -> RTNType
 {
   if (bpp < 0.0 || bpp > 64.0)
     return RTNType::InvalidParam;
@@ -22,13 +22,13 @@ auto SPECK3D_OMP_D::set_bpp(double bpp) -> RTNType
 }
 #endif
 
-void SPECK3D_OMP_D::set_num_threads(size_t n)
+void SPERR3D_OMP_D::set_num_threads(size_t n)
 {
   if (n > 0)
     m_num_threads = n;
 }
 
-auto SPECK3D_OMP_D::use_bitstream(const void* p, size_t total_len) -> RTNType
+auto SPERR3D_OMP_D::use_bitstream(const void* p, size_t total_len) -> RTNType
 {
   // This method parses the header of a bitstream and puts volume dimension and
   // chunk size information in respective member variables.
@@ -107,7 +107,7 @@ auto SPECK3D_OMP_D::use_bitstream(const void* p, size_t total_len) -> RTNType
   return RTNType::Good;
 }
 
-auto SPECK3D_OMP_D::decompress(const void* p) -> RTNType
+auto SPERR3D_OMP_D::decompress(const void* p) -> RTNType
 {
   auto eq0 = [](auto v) { return v == 0; };
   if (std::any_of(m_dims.begin(), m_dims.end(), eq0) ||
@@ -129,7 +129,7 @@ auto SPECK3D_OMP_D::decompress(const void* p) -> RTNType
   m_vol_buf.resize(total_vals);
 
   // Create number of decompressor instances equal to the number of threads
-  auto decompressors = std::vector<sperr::SPECK3D_Decompressor>(m_num_threads);
+  auto decompressors = std::vector<sperr::SPERR3D_Decompressor>(m_num_threads);
   auto chunk_rtn = std::vector<RTNType>(num_chunks * 3, RTNType::Good);
 
 // Each compressor instance takes on a chunk
@@ -169,28 +169,28 @@ auto SPECK3D_OMP_D::decompress(const void* p) -> RTNType
     return RTNType::Good;
 }
 
-auto SPECK3D_OMP_D::release_data() -> sperr::vecd_type&&
+auto SPERR3D_OMP_D::release_data() -> sperr::vecd_type&&
 {
   m_dims = {0, 0, 0};
   return std::move(m_vol_buf);
 }
 
-auto SPECK3D_OMP_D::view_data() const -> const std::vector<double>&
+auto SPERR3D_OMP_D::view_data() const -> const std::vector<double>&
 {
   return m_vol_buf;
 }
 
-auto SPECK3D_OMP_D::get_dims() const -> std::array<size_t, 3>
+auto SPERR3D_OMP_D::get_dims() const -> std::array<size_t, 3>
 {
   return m_dims;
 }
 
 template <typename T>
-auto SPECK3D_OMP_D::get_data() const -> std::vector<T>
+auto SPERR3D_OMP_D::get_data() const -> std::vector<T>
 {
   auto rtn_buf = std::vector<T>(m_vol_buf.size());
   std::copy(m_vol_buf.begin(), m_vol_buf.end(), rtn_buf.begin());
   return rtn_buf;
 }
-template auto SPECK3D_OMP_D::get_data() const -> std::vector<float>;
-template auto SPECK3D_OMP_D::get_data() const -> std::vector<double>;
+template auto SPERR3D_OMP_D::get_data() const -> std::vector<float>;
+template auto SPERR3D_OMP_D::get_data() const -> std::vector<double>;

--- a/src/SPERR_C_API.cpp
+++ b/src/SPERR_C_API.cpp
@@ -1,7 +1,7 @@
 #include "SPERR_C_API.h"
 
-#include "SPECK2D_Compressor.h"
-#include "SPECK2D_Decompressor.h"
+#include "SPERR2D_Compressor.h"
+#include "SPERR2D_Decompressor.h"
 
 #include "SPECK3D_OMP_C.h"
 #include "SPECK3D_OMP_D.h"
@@ -23,7 +23,7 @@ int C_API::sperr_qzcomp_2d(const void* src,
 
   // Setup the compressor
   const auto total_vals = dimx * dimy;
-  auto compressor = SPECK2D_Compressor();
+  auto compressor = SPERR2D_Compressor();
   auto rtn = sperr::RTNType::Good;
   switch (is_float) {
     case 0:  // double
@@ -75,7 +75,7 @@ int C_API::sperr_qzdecomp_2d(const void* src,
     return 1;
 
   // Use a decompressor to decompress this bitstream
-  auto decompressor = SPECK2D_Decompressor();
+  auto decompressor = SPERR2D_Decompressor();
   auto rtn = decompressor.use_bitstream(src, src_len);
   if (rtn != RTNType::Good)
     return -1;

--- a/src/SPERR_C_API.cpp
+++ b/src/SPERR_C_API.cpp
@@ -3,8 +3,8 @@
 #include "SPERR2D_Compressor.h"
 #include "SPERR2D_Decompressor.h"
 
-#include "SPECK3D_OMP_C.h"
-#include "SPECK3D_OMP_D.h"
+#include "SPERR3D_OMP_C.h"
+#include "SPERR3D_OMP_D.h"
 
 #ifdef QZ_TERM
 
@@ -135,7 +135,7 @@ int C_API::sperr_qzcomp_3d(const void* src,
 
   // Setup the compressor
   const auto total_vals = dimx * dimy * dimz;
-  auto compressor = SPECK3D_OMP_C();
+  auto compressor = SPERR3D_OMP_C();
   compressor.set_num_threads(nthreads);
   auto rtn = sperr::RTNType::Good;
   switch (is_float) {
@@ -195,7 +195,7 @@ int C_API::sperr_qzdecomp_3d(const void* src,
     return -1;
 
   // Use a decompressor to decompress this bitstream
-  auto decompressor = SPECK3D_OMP_D();
+  auto decompressor = SPERR3D_OMP_D();
   decompressor.set_num_threads(nthreads);
   auto rtn = decompressor.use_bitstream(src, src_len);
   if (rtn != RTNType::Good)

--- a/test_scripts/speck2d_unit_test.cpp
+++ b/test_scripts/speck2d_unit_test.cpp
@@ -1,6 +1,6 @@
 #include <cstdlib>
-#include "SPECK2D_Compressor.h"
-#include "SPECK2D_Decompressor.h"
+#include "SPERR2D_Compressor.h"
+#include "SPERR2D_Decompressor.h"
 #include "gtest/gtest.h"
 
 using sperr::RTNType;
@@ -44,7 +44,7 @@ class speck_tester {
     //
     // Use a compressor
     //
-    SPECK2D_Compressor compressor;
+    SPERR2D_Compressor compressor;
     if (compressor.copy_data(in_buf.data(), total_vals, m_dims) != RTNType::Good)
       return 1;
 
@@ -63,7 +63,7 @@ class speck_tester {
     //
     // Then use a decompressor
     //
-    SPECK2D_Decompressor decompressor;
+    SPERR2D_Decompressor decompressor;
     if (decompressor.use_bitstream(bitstream.data(), bitstream.size()) != RTNType::Good)
       return 1;
     if (decompressor.decompress() != RTNType::Good)

--- a/test_scripts/speck3d_unit_test.cpp
+++ b/test_scripts/speck3d_unit_test.cpp
@@ -1,8 +1,5 @@
-#include "SPECK3D_Compressor.h"
-#include "SPECK3D_Decompressor.h"
-
-#include "SPECK3D_OMP_C.h"
-#include "SPECK3D_OMP_D.h"
+#include "SPERR3D_OMP_C.h"
+#include "SPERR3D_OMP_D.h"
 
 #include <cstring>
 #include "gtest/gtest.h"
@@ -11,8 +8,7 @@ namespace {
 
 using sperr::RTNType;
 
-// Create a class that executes the entire pipeline, and calculates the error metrics
-// This class tests objects SPECK3D_OMP_C and SPECK3D_OMP_D
+// Create a class that executes the entire pipeline, and calculates the error metrics.
 class speck_tester_omp {
  public:
   speck_tester_omp(const char* in, sperr::dims_type dims, size_t num_t)
@@ -52,7 +48,7 @@ class speck_tester_omp {
     if (in_buf.size() != total_vals)
       return 1;
 
-    auto compressor = SPECK3D_OMP_C();
+    auto compressor = SPERR3D_OMP_C();
     compressor.set_num_threads(m_num_t);
 
     if (compressor.copy_data(in_buf.data(), total_vals, m_dims, m_chunk_dims) != RTNType::Good)
@@ -74,7 +70,7 @@ class speck_tester_omp {
     //
     // Use a decompressor
     //
-    auto decompressor = SPECK3D_OMP_D();
+    auto decompressor = SPERR3D_OMP_D();
     decompressor.set_num_threads(m_num_t);
     if (decompressor.use_bitstream(stream.data(), stream.size()) != RTNType::Good)
       return 1;

--- a/utilities/compressor_2d.cpp
+++ b/utilities/compressor_2d.cpp
@@ -1,5 +1,5 @@
-#include "SPECK2D_Compressor.h"
-#include "SPECK2D_Decompressor.h"
+#include "SPERR2D_Compressor.h"
+#include "SPERR2D_Decompressor.h"
 
 #include "CLI11.hpp"
 
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
   }
 
   auto rtn = sperr::RTNType::Good;
-  auto compressor = SPECK2D_Compressor();
+  auto compressor = SPERR2D_Compressor();
 
   // Pass data to the compressor
   if (use_double) {
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
     std::cout << "Average bpp = " << stream.size() * 8.0 / total_vals;
 
     // Use a decompressor to decompress and collect error statistics
-    SPECK2D_Decompressor decompressor;
+    SPERR2D_Decompressor decompressor;
     rtn = decompressor.use_bitstream(stream.data(), stream.size());
     if (rtn != RTNType::Good)
       return 1;

--- a/utilities/compressor_3d.cpp
+++ b/utilities/compressor_3d.cpp
@@ -1,4 +1,4 @@
-#include "SPECK3D_OMP_C.h"
+#include "SPERR3D_OMP_C.h"
 
 #include "CLI11.hpp"
 
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
   // Let's do the actual work
   //
   const size_t total_vals = dims[0] * dims[1] * dims[2];
-  SPECK3D_OMP_C compressor;
+  SPERR3D_OMP_C compressor;
   compressor.set_num_threads(omp_num_threads);
 
   auto orig = sperr::read_whole_file<uint8_t>(input_file);

--- a/utilities/decompressor_2d.cpp
+++ b/utilities/decompressor_2d.cpp
@@ -1,5 +1,5 @@
 #include <cassert>
-#include "SPECK2D_Decompressor.h"
+#include "SPERR2D_Decompressor.h"
 
 #include "CLI11.hpp"
 
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
   }
 
   // Use a decompressor
-  SPECK2D_Decompressor decompressor;
+  SPERR2D_Decompressor decompressor;
   auto rtn = decompressor.use_bitstream(in_stream.data(), in_stream.size());
   if (rtn != RTNType::Good) {
     std::cerr << "Use input stream error!" << std::endl;

--- a/utilities/decompressor_3d.cpp
+++ b/utilities/decompressor_3d.cpp
@@ -1,4 +1,4 @@
-#include "SPECK3D_OMP_D.h"
+#include "SPERR3D_OMP_D.h"
 
 #include "CLI11.hpp"
 
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
     std::cerr << "Read input stream error: " << input_file << std::endl;
     return 1;
   }
-  SPECK3D_OMP_D decompressor;
+  SPERR3D_OMP_D decompressor;
   decompressor.set_num_threads(omp_num_threads);
   if (decompressor.use_bitstream(in_stream.data(), in_stream.size()) != sperr::RTNType::Good) {
     std::cerr << "Read compressed file error: " << input_file << std::endl;

--- a/utilities/probe_3d_qz.cpp
+++ b/utilities/probe_3d_qz.cpp
@@ -1,8 +1,8 @@
-#include "SPECK3D_Compressor.h"
-#include "SPECK3D_Decompressor.h"
+#include "SPERR3D_Compressor.h"
+#include "SPERR3D_Decompressor.h"
 
-#include "SPECK3D_OMP_C.h"
-#include "SPECK3D_OMP_D.h"
+#include "SPERR3D_OMP_C.h"
+#include "SPERR3D_OMP_D.h"
 
 #include "CLI11.hpp"
 
@@ -29,7 +29,7 @@ auto test_configuration_omp(const T* in_buf,
 {
   // Setup
   const size_t total_vals = dims[0] * dims[1] * dims[2];
-  SPECK3D_OMP_C compressor;
+  SPERR3D_OMP_C compressor;
   compressor.toggle_conditioning(condi_settings);
   compressor.set_num_threads(omp_num_threads);
   auto rtn = compressor.copy_data(in_buf, total_vals, dims, chunks);
@@ -70,7 +70,7 @@ auto test_configuration_omp(const T* in_buf,
   }
 
   // Perform decompression
-  SPECK3D_OMP_D decompressor;
+  SPERR3D_OMP_D decompressor;
   decompressor.set_num_threads(omp_num_threads);
   rtn = decompressor.use_bitstream(encoded_stream.data(), encoded_stream.size());
   if (rtn != RTNType::Good)

--- a/utilities/probe_3d_size.cpp
+++ b/utilities/probe_3d_size.cpp
@@ -1,8 +1,5 @@
-#include "SPECK3D_Compressor.h"
-#include "SPECK3D_Decompressor.h"
-
-#include "SPECK3D_OMP_C.h"
-#include "SPECK3D_OMP_D.h"
+#include "SPERR3D_OMP_C.h"
+#include "SPERR3D_OMP_D.h"
 
 #include "CLI11.hpp"
 
@@ -28,7 +25,7 @@ auto test_configuration_omp(const T* in_buf,
 {
   // Setup
   const size_t total_vals = dims[0] * dims[1] * dims[2];
-  auto compressor = SPECK3D_OMP_C();
+  auto compressor = SPERR3D_OMP_C();
   auto rtn = compressor.copy_data(in_buf, total_vals, dims, chunks);
   if (rtn != RTNType::Good)
     return 1;
@@ -55,7 +52,7 @@ auto test_configuration_omp(const T* in_buf,
            double(encoded_stream.size() * 8) / double(total_vals));
 
   // Perform decompression
-  SPECK3D_OMP_D decompressor;
+  SPERR3D_OMP_D decompressor;
   decompressor.set_num_threads(omp_num_threads);
   rtn = decompressor.use_bitstream(encoded_stream.data(), encoded_stream.size());
   if (rtn != RTNType::Good)


### PR DESCRIPTION
This PR renames objects SPECK2D_Compressor, SPECK3D_Compressor, and SPECK3D_OMP_C (and their decompress counterparts) to use the name of SPERR. 