### PR TITLE
get rid of 10% coefficients being quantized test

### DIFF
--- a/include/SPECK_Storage.h
+++ b/include/SPECK_Storage.h
@@ -50,11 +50,16 @@ class SPECK_Storage {
   // Member variables
   //
   const size_t m_header_size = 10;  // See header definition in SPECK_Storage.cpp.
+  const size_t m_u64_garbage_val = std::numeric_limits<size_t>::max();
   size_t m_encode_budget = 0;
+  size_t m_LSP_mask_sum = 0;    // Number of TRUE values in `m_LSP_mask`.
+  size_t m_bit_idx = 0;         // Used for decode. Which bit we're at?
+  int32_t m_max_coeff_bit = 0;  // Maximum bitplane.
   int32_t m_qz_lev = sperr::lowest_int32;
-  double m_target_psnr = sperr::max_d;
-  double m_target_pwe = 0.0;
   double m_data_range = sperr::max_d;  // range of data before DWT.
+  double m_target_psnr = sperr::max_d;
+  double m_target_pwe = 0.0;  // used in fixed-PWE mode
+  double m_threshold = 0.0;   // Threshold that's used for an iteration.
 
   // Use a cache variable to store the current compression mode.
   // The compression mode, however, is NOT set or determined by `m_mode_cache`. It is determined
@@ -62,8 +67,7 @@ class SPECK_Storage {
   // and can be retrieved by calling function sperr::compression_mode().
   CompMode m_mode_cache = CompMode::Unknown;
 
-  //
-  // A few data structures shared by both 2D and 3D SPECK algorithm
+  // Data storage shared by both 2D and 3D SPECK.
   //
   std::vector<double> m_coeff_buf;  // Wavelet coefficients
   std::vector<bool> m_bit_buffer;   // Bitstream produced by the algorithm
@@ -71,14 +75,8 @@ class SPECK_Storage {
   std::vector<size_t> m_LSP_new;    // List of newly found significant pixels
   std::vector<bool> m_LSP_mask;     // Significant pixels previously found
   std::vector<bool> m_sign_array;   // Keep the signs of every coefficient
-  vec8_type m_encoded_stream;
-
-  size_t m_LSP_mask_sum = 0;     // Number of TRUE values in `m_LSP_mask`.
-  size_t m_bit_idx = 0;          // Used for decode. Which bit we're at?
-  double m_threshold = 0.0;      // Threshold that's used for an iteration.
-  int32_t m_max_coeff_bit = 0;   // Maximum bitplane.
-  dims_type m_dims = {0, 0, 0};  // Dimension of the 2D/3D volume
-  const size_t m_u64_garbage_val = std::numeric_limits<size_t>::max();
+  vec8_type m_encoded_stream;       // Stores the SPECK bitstream
+  dims_type m_dims = {0, 0, 0};     // Dimension of the 2D/3D volume
 
   //
   // A few data members for error estimation
@@ -86,7 +84,6 @@ class SPECK_Storage {
   std::vector<double> m_orig_coeff;
   std::vector<double> m_qz_coeff;
   std::vector<double> m_calc_mse_buf;  // temporary buffer facilitating MSE calculation
-  size_t m_num_qz_coeff = 0;           // number of quantized (non-zero) coefficients
 
   //
   // Member methods
@@ -96,7 +93,7 @@ class SPECK_Storage {
   auto m_refinement_pass_decode() -> RTNType;
 
   // Is there anything demanding the termination of iterations?
-  auto m_termination_check(size_t bitplane) -> RTNType;
+  auto m_termination_check(size_t bitplane_idx) -> RTNType;
 };
 
 };  // namespace sperr

--- a/src/SPECK2D.cpp
+++ b/src/SPECK2D.cpp
@@ -74,7 +74,6 @@ auto sperr::SPECK2D::encode() -> RTNType
     m_orig_coeff.clear();
     m_qz_coeff.clear();
   }
-  m_num_qz_coeff = 0;
 
   // Mark every coefficient as insignificant
   m_LSP_mask.assign(m_coeff_buf.size(), false);
@@ -283,7 +282,6 @@ auto sperr::SPECK2D::m_process_P_encode(size_t loc, size_t& counter, bool need_d
 
     if (m_mode_cache == CompMode::FixedPSNR || m_mode_cache == CompMode::FixedPWE) {
       m_qz_coeff[pixel_idx] = m_threshold * 1.5;
-      m_num_qz_coeff++;
     }
   }
 

--- a/src/SPECK3D.cpp
+++ b/src/SPECK3D.cpp
@@ -80,7 +80,6 @@ auto sperr::SPECK3D::encode() -> RTNType
     m_orig_coeff.clear();
     m_qz_coeff.clear();
   }
-  m_num_qz_coeff = 0;
 
   // Mark every coefficient as insignificant
   m_LSP_mask.assign(m_coeff_buf.size(), false);
@@ -343,7 +342,6 @@ auto sperr::SPECK3D::m_process_P_encode(size_t loc, SigType sig, size_t& counter
 
     if (m_mode_cache == CompMode::FixedPSNR || m_mode_cache == CompMode::FixedPWE) {
       m_qz_coeff[pixel_idx] = m_threshold * 1.5;
-      m_num_qz_coeff++;
     }
   }
 

--- a/src/SPECK_Storage.cpp
+++ b/src/SPECK_Storage.cpp
@@ -256,7 +256,7 @@ auto sperr::SPECK_Storage::m_refinement_pass_decode() -> RTNType
   return RTNType::Good;
 }
 
-auto sperr::SPECK_Storage::m_termination_check(size_t bitplane) -> RTNType
+auto sperr::SPECK_Storage::m_termination_check(size_t bitplane_idx) -> RTNType
 {
   assert(m_mode_cache != CompMode::Unknown);
 
@@ -264,7 +264,7 @@ auto sperr::SPECK_Storage::m_termination_check(size_t bitplane) -> RTNType
     case CompMode::FixedQz: {
       assert(m_max_coeff_bit >= m_qz_lev);
       const size_t num_qz_levs = m_max_coeff_bit - m_qz_lev;
-      if (bitplane >= num_qz_levs)
+      if (bitplane_idx >= num_qz_levs)
         return RTNType::QzLevelReached;
       else
         return RTNType::Good;
@@ -273,11 +273,6 @@ auto sperr::SPECK_Storage::m_termination_check(size_t bitplane) -> RTNType
       assert(m_orig_coeff.size() == m_qz_coeff.size());
       assert(!m_orig_coeff.empty());
       assert(m_data_range != sperr::max_d);
-
-      // If there's less than 10% of coefficients being non-zero, we decide
-      // that continue encoding without checking PSNR.
-      if (static_cast<double>(m_num_qz_coeff) / static_cast<double>(m_qz_coeff.size()) < 0.1)
-        return RTNType::Good;
 
       const auto mse = sperr::calc_mse(m_orig_coeff, m_qz_coeff, m_calc_mse_buf);
       const auto psnr = std::log10(m_data_range * m_data_range / mse) * 10.0;
@@ -292,11 +287,6 @@ auto sperr::SPECK_Storage::m_termination_check(size_t bitplane) -> RTNType
       assert(m_orig_coeff.size() == m_qz_coeff.size());
       assert(!m_orig_coeff.empty());
       assert(m_target_pwe > 0.0);
-
-      // If there's less than 10% of coefficients being non-zero, we decide
-      // that continue encoding without checking PWE.
-      if (static_cast<double>(m_num_qz_coeff) / static_cast<double>(m_qz_coeff.size()) < 0.1)
-        return RTNType::Good;
 
       const auto mse = sperr::calc_mse(m_orig_coeff, m_qz_coeff, m_calc_mse_buf);
       const auto rmse = std::sqrt(mse);


### PR DESCRIPTION
Estimate MSE at every iteration instead of when there are more than 10% coefficients being quantized. 